### PR TITLE
EUX-1057 institusjoner endepunkt

### DIFF
--- a/src/ducks/kodeverk/selectors.js
+++ b/src/ducks/kodeverk/selectors.js
@@ -7,11 +7,6 @@
 
 import { createSelector } from 'reselect';
 
-export const institusjonerSelector = createSelector(
-  state => state.kodeverk.data.institusjoner,
-  institusjoner => institusjoner
-);
-
 export const familierelasjonerSelector = createSelector(
   state => state.kodeverk.data.familierelasjoner,
   familierelasjoner => familierelasjoner

--- a/src/ducks/rinasak/operations.js
+++ b/src/ducks/rinasak/operations.js
@@ -16,7 +16,7 @@ import * as Types from './types';
 const transformData = data => {
   if (data.tilleggsopplysninger.familierelasjoner.length > 0) {
     const {
-      buctype, fnr, land, mottakerID, sedtype, sektor,
+      buctype, fnr, landKode: land, mottakerID, sedtype, sektor,
       tilleggsopplysninger,
     } = data;
     const familierelasjoner = tilleggsopplysninger.familierelasjoner.map(relasjon => ({ ...relasjon, fdato: formatterDatoTilISO(relasjon.fdato) }));

--- a/src/felles-komponenter/panelHeader/panelHeader.less
+++ b/src/felles-komponenter/panelHeader/panelHeader.less
@@ -4,6 +4,7 @@
   display:flex;
   flex-direction: row;
   align-content: center;
+  margin-right: 6em;
 }
 
 .panelheader__ikon {
@@ -26,6 +27,7 @@
 
 .panelheader__tittel__hoved {
   text-align:left;
+  min-width: 300px;
 }
 
 .panelheader__tittel__under {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -4,6 +4,7 @@ import * as Saksbehandler from './modules/saksbehandler';
 import * as Personer from './modules/personer';
 import * as Rina from './modules/rina';
 import * as Dokumenter from './modules/dokumenter';
+import * as Institusjoner from './modules/institusjoner';
 // from .env or .env.local
 // const API_BASE_URL = `${process.env.REACT_APP_API_BASE_URL}`;
 // console.log('process.env', process.env);
@@ -15,4 +16,5 @@ export {
   Kodeverk,
   Saksbehandler,
   Personer,
+  Institusjoner,
 };

--- a/src/services/modules/institusjoner.js
+++ b/src/services/modules/institusjoner.js
@@ -1,0 +1,8 @@
+import { getAsJson } from '../utils';
+import { API_BASE_URL } from '../api-constants';
+
+// eslint-disable-next-line import/prefer-default-export
+export function hent(buctype, landkode) {
+  const URI_INSTITUSJONER = `${API_BASE_URL}institusjoner/${buctype}/?landkode=${landkode}`;
+  return getAsJson(URI_INSTITUSJONER);
+}

--- a/src/sider/opprettsak.js
+++ b/src/sider/opprettsak.js
@@ -22,7 +22,7 @@ const uuid = require('uuid/v4');
 class OpprettSak extends Component {
   state = {
     landKode: '',
-    institusjonsid: '',
+    mottakerID: '',
     institusjoner: [],
   };
   oppdaterLandKode = event => {
@@ -34,18 +34,18 @@ class OpprettSak extends Component {
   };
 
   oppdaterInstitusjonKode = event => {
-    const institusjonsid = event.target.value;
+    const mottakerID = event.target.value;
     const { institusjoner } = this.state;
-    this.setState({ institusjonsid, institusjoner });
+    this.setState({ mottakerID, institusjoner });
   };
 
   skjemaSubmit = values => {
     const { submitFailed, sendSkjema } = this.props;
-    const { institusjonsid, landKode } = this.state;
+    const { mottakerID, landKode } = this.state;
 
     if (submitFailed) return;
 
-    const vaskedeVerdier = { ...values, institusjonsid, landKode };
+    const vaskedeVerdier = { ...values, mottakerID, landKode };
     delete vaskedeVerdier.fnrErGyldig;
     delete vaskedeVerdier.fnrErSjekket;
     sendSkjema(vaskedeVerdier);
@@ -135,9 +135,9 @@ class OpprettSak extends Component {
 
               </Nav.Column>
               <Nav.Column xs="3">
-                <Nav.Select bredde="xl" disabled={!oppgittFnrErValidert} value={this.state.institusjonsid} onChange={this.oppdaterInstitusjonKode} label="Mottaker institusjon">
+                <Nav.Select bredde="xl" disabled={!oppgittFnrErValidert} value={this.state.mottakerID} onChange={this.oppdaterInstitusjonKode} label="Mottaker institusjon">
                   <option value="0" />
-                  {institusjoner && institusjoner.map(element => <option value={element.institusjonsid} key={uuid()}>{element.institusjonsid}</option>)}
+                  {institusjoner && institusjoner.map(element => <option value={element.mottakerID} key={uuid()}>{element.mottakerID}</option>)}
                 </Nav.Select>
               </Nav.Column>
             </Nav.Row>

--- a/src/sider/opprettsak.js
+++ b/src/sider/opprettsak.js
@@ -148,6 +148,9 @@ class OpprettSak extends Component {
               <Nav.Column xs="3">
                 <Nav.Hovedknapp onClick={this.props.handleSubmit(this.skjemaSubmit)} spinner={['PENDING'].includes(status)} disabled={['PENDING'].includes(status)}>Opprett sak i RINA</Nav.Hovedknapp>
               </Nav.Column>
+              <Nav.Column xs="1">
+                &nbsp;
+              </Nav.Column>
               <Nav.Column xs="3">
                 <Nav.Lenke href="/" ariaLabel="Navigasjonslink tilbake til forsiden">
                  AVSLUTT
@@ -155,7 +158,7 @@ class OpprettSak extends Component {
               </Nav.Column>
             </Nav.Row>
             <Nav.Row>
-              <Nav.Column xs="3">
+              <Nav.Column xs="6">
                 <StatusLinje status={status} url={responsLenke} tittel={`Saksnummer: ${rinasaksnummer}`} />
                 {errdata && errdata.status && <p>{errdata.message}</p>}
               </Nav.Column>
@@ -246,7 +249,7 @@ const validering = values => {
   const buctype = !values.buctype ? 'Du må velge buctype.' : null;
   const sedtype = !values.sedtype ? 'Du må velge sedtype.' : null;
   const land = !values.land ? 'Du må velge land.' : null;
-  const mottakerID = !values.mottakerID ? 'Du må velge institusjon.' : null;
+  const mottakerID = !values.mottakerID ? 'Du må velge institusjon.' : null; // TODO Bytte med 'institusjonid'
 
   return {
     fnr: fnr || fnrErUgyldig,

--- a/src/sider/opprettsak.js
+++ b/src/sider/opprettsak.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { reduxForm, formValueSelector, clearAsyncError, stopSubmit, change } from 'redux-form';
 import PT from 'prop-types';
 
+import * as Api from '../services/api';
 import * as MPT from '../proptypes/';
 import * as Nav from '../utils/navFrontend';
 import * as Skjema from '../felles-komponenter/skjema';
@@ -19,11 +20,32 @@ import './opprettsak.css';
 const uuid = require('uuid/v4');
 
 class OpprettSak extends Component {
+  state = {
+    landKode: '',
+    institusjonsid: '',
+    institusjoner: [],
+  };
+  oppdaterLandKode = event => {
+    const landKode = event.target.value;
+    const { buctype } = this.props;
+    Api.Institusjoner.hent(buctype, landKode).then(institusjoner => {
+      this.setState({ landKode, institusjoner });
+    });
+  };
+
+  oppdaterInstitusjonKode = event => {
+    const institusjonsid = event.target.value;
+    const { institusjoner } = this.state;
+    this.setState({ institusjonsid, institusjoner });
+  };
+
   skjemaSubmit = values => {
     const { submitFailed, sendSkjema } = this.props;
+    const { institusjonsid, landKode } = this.state;
+
     if (submitFailed) return;
 
-    const vaskedeVerdier = { ...values };
+    const vaskedeVerdier = { ...values, institusjonsid, landKode };
     delete vaskedeVerdier.fnrErGyldig;
     delete vaskedeVerdier.fnrErSjekket;
     sendSkjema(vaskedeVerdier);
@@ -55,12 +77,14 @@ class OpprettSak extends Component {
   render() {
     const {
       landkoder, sedtyper, sektor, buctyper,
-      inntastetFnr, status, errdata, institusjoner,
+      inntastetFnr, status, errdata,
       valgtSektor,
       settFnrSjekket, settFnrGyldighet,
       fnrErGyldig, fnrErSjekket,
       opprettetSak,
     } = this.props;
+
+    const { institusjoner } = this.state;
 
     const { rinasaksnummer, url: responsLenke } = opprettetSak;
 
@@ -104,14 +128,17 @@ class OpprettSak extends Component {
             </Nav.Row>
             <Nav.Row className="">
               <Nav.Column xs="3">
-                <Skjema.Select feltNavn="land" label="Land" bredde="s" disabled={!oppgittFnrErValidert}>
+                <Nav.Select bredde="xl" disabled={!oppgittFnrErValidert} value={this.state.landKode} onChange={this.oppdaterLandKode} label="Land">
+                  <option value="0" />
                   {landkoder && landkoder.map(element => <option value={element.kode} key={uuid()}>{element.term}</option>)}
-                </Skjema.Select>
+                </Nav.Select>
+
               </Nav.Column>
               <Nav.Column xs="3">
-                <Skjema.Select feltNavn="mottakerID" label="Mottaker institusjon" bredde="s" disabled={!oppgittFnrErValidert}>
-                  {institusjoner && institusjoner.map(element => <option value={element.kode} key={uuid()}>{element.term}</option>)}
-                </Skjema.Select>
+                <Nav.Select bredde="xl" disabled={!oppgittFnrErValidert} value={this.state.institusjonsid} onChange={this.oppdaterInstitusjonKode} label="Mottaker institusjon">
+                  <option value="0" />
+                  {institusjoner && institusjoner.map(element => <option value={element.institusjonsid} key={uuid()}>{element.institusjonsid}</option>)}
+                </Nav.Select>
               </Nav.Column>
             </Nav.Row>
             <Nav.Row className="">
@@ -148,10 +175,10 @@ OpprettSak.propTypes = {
   settFnrSjekket: PT.func.isRequired,
   submitFailed: PT.bool.isRequired,
   landkoder: PT.arrayOf(MPT.Kodeverk),
-  institusjoner: PT.arrayOf(MPT.Kodeverk),
   sedtyper: PT.arrayOf(MPT.Kodeverk),
   sektor: PT.arrayOf(MPT.Kodeverk),
   buctyper: PT.arrayOf(MPT.Kodeverk),
+  buctype: PT.string,
   fnrErGyldig: PT.bool,
   fnrErSjekket: PT.bool,
   inntastetFnr: PT.string,
@@ -167,10 +194,10 @@ OpprettSak.propTypes = {
 
 OpprettSak.defaultProps = {
   landkoder: undefined,
-  institusjoner: undefined,
   sedtyper: undefined,
   sektor: undefined,
   buctyper: undefined,
+  buctype: undefined,
   fnrErGyldig: undefined,
   fnrErSjekket: undefined,
   inntastetFnr: '',
@@ -190,11 +217,11 @@ const mapStateToProps = state => ({
     },
   },
   landkoder: KodeverkSelectors.landkoderSelector(state),
-  institusjoner: KodeverkSelectors.institusjonerSelector(state),
   sektor: KodeverkSelectors.sektorSelector(state),
   fnrErGyldig: skjemaSelector(state, 'fnrErGyldig'),
   fnrErSjekket: skjemaSelector(state, 'fnrErSjekket'),
   sedtyper: RinasakSelectors.sedtypeSelector(state),
+  buctype: skjemaSelector(state, 'buctype'),
   buctyper: RinasakSelectors.buctyperSelector(state),
   inntastetFnr: skjemaSelector(state, 'fnr'),
   valgtSektor: skjemaSelector(state, 'sektor'),

--- a/src/sider/opprettsak.less
+++ b/src/sider/opprettsak.less
@@ -15,12 +15,12 @@
 .personsok__kort {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-start;
   margin: .6em 0;
   align-items: center;
 
   .panelheader {
-    flex: 1;
+    flex: 0 1 auto;
   }
 
   .fodselsdato {

--- a/src/sider/personsok.js
+++ b/src/sider/personsok.js
@@ -30,6 +30,13 @@ const PersonKort = ({ person }) => {
     <div>
       <Nav.Panel className="personsok__kort">
         <PanelHeader ikon={IkonFraKjonn(kjoenn)} tittel={`${fornavn} ${etternavn}`} undertittel={panelUndertittel} />
+        <Nav.Knapp
+          className="familierelasjoner__knapp familierelasjoner__knapp--slett"
+          onClick={() => window.location.reload()}
+        >
+          <Nav.Ikon kind="trashcan" size="20" className="familierelasjoner__knapp__ikon" />
+          <div className="familierelasjoner__knapp__label">Fjern</div>
+        </Nav.Knapp>
       </Nav.Panel>
     </div>
   );

--- a/src/sider/personsok.less
+++ b/src/sider/personsok.less
@@ -1,3 +1,5 @@
+@import '../constants';
+
 .personsok {
   margin-bottom: 2em;
 
@@ -12,11 +14,10 @@
 
   .personsok__knapp {
     display: flex;
-    flex-grow: 0;
     flex: 0;
     height: 2.4em;
     align-self: flex-start;
-    margin: 1.9em 0 0em 1em;
+    margin: 1.9em 0 0 1em;
   }
 
   .personsok__kort {
@@ -25,5 +26,36 @@
 
   .personsok__advarsel {
     margin-top: 1em;
+  }
+  .familierelasjoner__knapp {
+    display: flex;
+    align-self: center;
+    justify-self: flex-end;
+
+    .familierelasjoner__knapp__label {
+      display: flex;
+      align-self: center;
+    }
+  }
+  .familierelasjoner__knapp__ikon {
+    margin: -0.0em 0.5em 0 0;
+
+    path {
+      stroke: @blue-nav;
+    }
+  }
+  .knapp--disabled {
+    path {
+      stroke: @white !important;
+    }
+  }
+
+  .familierelasjoner__knapp {
+
+    &:hover:not(.knapp--disabled) {
+      .familierelasjoner__knapp__ikon path {
+        stroke: @white !important;
+      }
+    }
   }
 }


### PR DESCRIPTION
Reimplementasjon av nedtrekksliste. Innhold av institusjoner blir nå hentet dynamisk vha nytt endepunkt http://localhost:3000/api/institusjoner/:BUC/?landkode=LANDKODE
Fjernet institusjoner fra kodeverk.
Dersom det ikke finnes relevant institusjon, blir nedtrekkslisten tom.
To nye knapper er lagt til. "AVSLUTT" link, og "Fjern" aka reset knapp for hele skjema.