### PR TITLE
Eux 1971 feilretting etter hotfix oktober

### DIFF
--- a/cypress/integration/eux_web_app/opprettsak/avsluttModal_spec.js
+++ b/cypress/integration/eux_web_app/opprettsak/avsluttModal_spec.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-undef */
+describe('Personpanel', () => {
+  beforeEach(() => {
+    cy.visit('/opprett');
+  });
+  it('viser modal ved klikk', () => {
+    cy.get('[aria-label="Navigasjonslink tilbake til forsiden"]')
+      .click();
+
+    cy.get('[role="dialog"]')
+      .should('exist');
+  });
+  it('navigerer til forside ved klikk på avbryt', () => {
+    cy.get('[aria-label="Navigasjonslink tilbake til forsiden"]')
+      .click();
+
+    cy.get('[data-cy="avbryt-modal-hovedknapp"]')
+      .click();
+
+    cy.url()
+      .should('be.equal', 'http://localhost:3000/');
+  });
+  it('lukker modal ved klikk på fortsett', () => {
+    cy.get('[aria-label="Navigasjonslink tilbake til forsiden"]')
+      .click();
+
+    cy.get('[data-cy="fortsett-modal-hovedknapp"]')
+      .click();
+
+    cy.get('[role="dialog"]')
+      .should('not.exist');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-dom": "^16.10.2",
     "react-highcharts": "^16.1.0",
     "react-maskedinput": "^4.0.1",
-    "react-modal": "^3.8.2",
+    "react-modal": "^3.10.1",
     "react-motion": "^0.5.2",
     "react-on-screen": "^2.1.1",
     "react-pdf": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "react-dom": "^16.10.2",
     "react-highcharts": "^16.1.0",
     "react-maskedinput": "^4.0.1",
-    "react-modal": "^3.10.1",
     "react-modal": "^3.8.2",
     "react-motion": "^0.5.2",
     "react-on-screen": "^2.1.1",
@@ -186,5 +185,5 @@
       }
     }
   },
-  "_id": "neessi@1.0.0"
+  "_id": "neessi@1.1.0"
 }

--- a/src/komponenter/AvsluttModal.js
+++ b/src/komponenter/AvsluttModal.js
@@ -4,12 +4,11 @@ import { Hovedknapp, Column, Row, Container, Modal, Undertittel, Normaltekst } f
 
 import './avsluttModal.css';
 
-Modal.setAppElement('#root');
-
 const avsluttModal = props => {
   const { visModal, closeModal } = props;
   return (
     <Modal
+      ariaHideApp={false}
       isOpen={visModal}
       onRequestClose={() => closeModal()}
       closeButton={false}
@@ -18,7 +17,7 @@ const avsluttModal = props => {
       <div className="modal__innhold">
         <Container align="center" fluid>
           <Row className="modal__overskrift">
-            <Undertittel> Er du sikker på at du vil avbryte? </Undertittel>
+            <Undertittel>Er du sikker på at du vil avbryte?</Undertittel>
           </Row >
           <Row className="modal__tekst">
             <Normaltekst>Informasjonen du har fyllt inn hittil vil ikke bli lagret.</Normaltekst>

--- a/src/komponenter/AvsluttModal.js
+++ b/src/komponenter/AvsluttModal.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PT from 'prop-types';
-import { Hovedknapp, Column, Row, Container, Modal, Undertittel, Normaltekst } from '../utils/navFrontend';
+import * as Nav from '../utils/navFrontend';
 
 import './avsluttModal.css';
 
-const avsluttModal = props => {
+const AvsluttModal = props => {
   const { visModal, closeModal } = props;
   return (
-    <Modal
+    <Nav.Modal
       ariaHideApp={false}
       isOpen={visModal}
       onRequestClose={() => closeModal()}
@@ -15,33 +15,33 @@ const avsluttModal = props => {
       contentLabel="Bekreft navigasjon tilbake til forsiden"
     >
       <div className="modal__innhold">
-        <Container align="center" fluid>
-          <Row className="modal__overskrift">
-            <Undertittel>Er du sikker på at du vil avbryte?</Undertittel>
-          </Row >
-          <Row className="modal__tekst">
-            <Normaltekst>Informasjonen du har fyllt inn hittil vil ikke bli lagret.</Normaltekst>
-          </Row>
-          <Row>
-            <Column xs="6">
+        <Nav.Container align="center" fluid>
+          <Nav.Row className="modal__overskrift">
+            <Nav.Undertittel>Er du sikker på at du vil avbryte?</Nav.Undertittel>
+          </Nav.Row >
+          <Nav.Row className="modal__tekst">
+            <Nav.Normaltekst>Informasjonen du har fyllt inn hittil vil ikke bli lagret.</Nav.Normaltekst>
+          </Nav.Row>
+          <Nav.Row>
+            <Nav.Column xs="6">
               {/* Hack for å bruke en nav-knapp som lenke */}
               <a href="/" tabIndex="-1">
-                <Hovedknapp className="modal__knapp" data-cy="avbryt-modal-hovedknapp">JA, AVBRYT</Hovedknapp>
+                <Nav.Hovedknapp className="modal__knapp" data-cy="avbryt-modal-hovedknapp">JA, AVBRYT</Nav.Hovedknapp>
               </a>
-            </Column >
-            <Column xs="6">
-              <Hovedknapp className="modal__knapp" onClick={closeModal} data-cy="fortsett-modal-hovedknapp">NEI, FORTSETT</Hovedknapp>
-            </Column >
-          </Row>
-        </Container>
+            </Nav.Column >
+            <Nav.Column xs="6">
+              <Nav.Hovedknapp className="modal__knapp" onClick={closeModal} data-cy="fortsett-modal-hovedknapp">NEI, FORTSETT</Nav.Hovedknapp>
+            </Nav.Column >
+          </Nav.Row>
+        </Nav.Container>
       </div >
-    </Modal>
+    </Nav.Modal>
   );
 };
 
-avsluttModal.propTypes = {
+AvsluttModal.propTypes = {
   visModal: PT.bool.isRequired,
   closeModal: PT.func.isRequired,
 };
 
-export default avsluttModal;
+export default AvsluttModal;

--- a/src/komponenter/AvsluttModal.js
+++ b/src/komponenter/AvsluttModal.js
@@ -26,11 +26,11 @@ const avsluttModal = props => {
             <Column xs="6">
               {/* Hack for å bruke en nav-knapp som lenke */}
               <a href="/" tabIndex="-1">
-                <Hovedknapp className="modal__knapp">JA, AVBRYT</Hovedknapp>
+                <Hovedknapp className="modal__knapp" data-cy="avbryt-modal-hovedknapp">JA, AVBRYT</Hovedknapp>
               </a>
             </Column >
             <Column xs="6">
-              <Hovedknapp className="modal__knapp" onClick={closeModal}>NEI, FORTSETT</Hovedknapp>
+              <Hovedknapp className="modal__knapp" onClick={closeModal} data-cy="fortsett-modal-hovedknapp">NEI, FORTSETT</Hovedknapp>
             </Column >
           </Row>
         </Container>

--- a/src/komponenter/AvsluttModal.test.js
+++ b/src/komponenter/AvsluttModal.test.js
@@ -21,7 +21,7 @@ describe(('DokumentKort Test Suite'), () => {
     it('mounter Modal med korrekte props', () => {
       const component = wrapper.find(Nav.Modal);
       expect(component).toHaveLength(1);
-      expect(component.props().isOpen).toEqual(false);
+      expect(component.props().isOpen).toBeFalsy();
       expect(typeof (component.props().onRequestClose)).toEqual('function');
       expect(component.props()).toHaveProperty('contentLabel', 'Bekreft navigasjon tilbake til forsiden');
     });

--- a/src/komponenter/AvsluttModal.test.js
+++ b/src/komponenter/AvsluttModal.test.js
@@ -2,8 +2,7 @@
 import React from 'react';
 
 import AvsluttModal from './AvsluttModal';
-import { Hovedknapp, Modal, Undertittel, Normaltekst } from '../utils/navFrontend';
-
+import * as Nav from '../utils/navFrontend';
 
 let wrapper;
 
@@ -20,31 +19,31 @@ describe(('DokumentKort Test Suite'), () => {
       expect(wrapper).toHaveLength(1);
     });
     it('mounter Modal med korrekte props', () => {
-      const component = wrapper.find(Modal);
+      const component = wrapper.find(Nav.Modal);
       expect(component).toHaveLength(1);
       expect(component.props().isOpen).toEqual(false);
       expect(typeof (component.props().onRequestClose)).toEqual('function');
       expect(component.props()).toHaveProperty('contentLabel', 'Bekreft navigasjon tilbake til forsiden');
     });
     it('viser Undertittel med props', () => {
-      const component = wrapper.find(Undertittel);
+      const component = wrapper.find(Nav.Undertittel);
       expect(component).toHaveLength(1);
       expect(component.children().text()).toEqual('Er du sikker på at du vil avbryte?');
     });
     it('viser Normaltekst med props', () => {
-      const component = wrapper.find(Normaltekst);
+      const component = wrapper.find(Nav.Normaltekst);
       expect(component).toHaveLength(1);
       expect(component.children().text()).toEqual('Informasjonen du har fyllt inn hittil vil ikke bli lagret.');
     });
     it('viser Hovedknapper med props', () => {
-      const component = wrapper.find(Hovedknapp);
+      const component = wrapper.find(Nav.Hovedknapp);
       expect(component).toHaveLength(2);
       expect(component.at(0).children().text()).toEqual('JA, AVBRYT');
       expect(component.at(1).children().text()).toEqual('NEI, FORTSETT');
       expect(component.at(1).props().onClick).toEqual(closeModal);
     });
     it('avslutt Hovedknapp lukker modal ved klikk', () => {
-      const component = wrapper.find(Hovedknapp);
+      const component = wrapper.find(Nav.Hovedknapp);
       component.at(1).props().onClick();
       expect(closeModal).toHaveBeenCalledTimes(1);
     });

--- a/src/komponenter/avsluttModal.test.js
+++ b/src/komponenter/avsluttModal.test.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-undef */
+import React from 'react';
+
+import AvsluttModal from './AvsluttModal';
+import { Hovedknapp, Modal, Undertittel, Normaltekst } from '../utils/navFrontend';
+
+
+let wrapper;
+
+describe(('DokumentKort Test Suite'), () => {
+  const closeModal = jest.fn();
+  beforeEach(() => {
+    wrapper = shallow(<AvsluttModal closeModal={closeModal} visModal={false} />);
+  });
+  afterEach(() => {
+    closeModal.mockClear();
+  });
+  describe('Presentasjon', () => {
+    it('somketest', () => {
+      expect(wrapper).toHaveLength(1);
+    });
+    it('mounter Modal med korrekte props', () => {
+      const component = wrapper.find(Modal);
+      expect(component).toHaveLength(1);
+      expect(component.props().isOpen).toEqual(false);
+      expect(typeof (component.props().onRequestClose)).toEqual('function');
+      expect(component.props()).toHaveProperty('contentLabel', 'Bekreft navigasjon tilbake til forsiden');
+    });
+    it('viser Undertittel med props', () => {
+      const component = wrapper.find(Undertittel);
+      expect(component).toHaveLength(1);
+      expect(component.children().text()).toEqual('Er du sikker på at du vil avbryte?');
+    });
+    it('viser Normaltekst med props', () => {
+      const component = wrapper.find(Normaltekst);
+      expect(component).toHaveLength(1);
+      expect(component.children().text()).toEqual('Informasjonen du har fyllt inn hittil vil ikke bli lagret.');
+    });
+    it('viser Hovedknapper med props', () => {
+      const component = wrapper.find(Hovedknapp);
+      expect(component).toHaveLength(2);
+      expect(component.at(0).children().text()).toEqual('JA, AVBRYT');
+      expect(component.at(1).children().text()).toEqual('NEI, FORTSETT');
+      expect(component.at(1).props().onClick).toEqual(closeModal);
+    });
+    it('avslutt Hovedknapp lukker modal ved klikk', () => {
+      const component = wrapper.find(Hovedknapp);
+      component.at(1).props().onClick();
+      expect(closeModal).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/sider/opprettsak.test.js
+++ b/src/sider/opprettsak.test.js
@@ -13,6 +13,7 @@ import { StatusLinje } from '../felles-komponenter/statuslinje';
 import PersonSok from './personsok';
 import FamilieRelasjonsComponent from '../felles-komponenter/skjema/PersonOgFamilieRelasjoner';
 import { ArbeidsforholdController, BehandlingsTemaer, Fagsaker } from './sak';
+import AvsluttModal from '../komponenter/AvsluttModal';
 
 
 const initialStore = createStore();
@@ -35,6 +36,7 @@ describe(('Opprettsak Test Suite'), () => {
         tema: '',
         fagsaker: [],
         saksID: '',
+        visModal: false,
       });
     });
   });
@@ -242,17 +244,16 @@ describe(('Opprettsak Test Suite'), () => {
         const component = wrapper.find(Nav.Knapp);
         expect(component).toHaveLength(0);
       });
-      // TODO lenker trenger css id
       it('Lenke vises hvis sektor er valgt', () => {
         wrapper.setProps({ valgtSektor: 'FB' });
         const component = wrapper.find(Nav.Lenke);
-        expect(component).toHaveLength(2);
-        expect(component.at(0).props()).toHaveProperty('ariaLabel', 'Opprett ny sak i GOSYS');
+        expect(component).toHaveLength(1);
+        expect(component.props()).toHaveProperty('ariaLabel', 'Opprett ny sak i GOSYS');
       });
       it('Lenke vises ikke hvis !sektor', () => {
         wrapper.setProps({ valgtSektor: undefined });
         const component = wrapper.find(Nav.Lenke);
-        expect(component).toHaveLength(1);
+        expect(component).toHaveLength(0);
       });
     });
     describe('Fagsaker', () => {
@@ -289,12 +290,11 @@ describe(('Opprettsak Test Suite'), () => {
       expect(component.props()).toHaveProperty('disabled', true);
       expect(handleSubmit).toHaveBeenCalledTimes(1);
     });
-    it('Lenke vises med props', () => {
-      wrapper.setProps({ valgtSektor: 'FB' });
-      const component = wrapper.find(Nav.Lenke);
-      expect(component).toHaveLength(2);
-      expect(component.at(1).props()).toHaveProperty('href', '/');
-      expect(component.at(1).props()).toHaveProperty('ariaLabel', 'Navigasjonslink tilbake til forsiden');
+    it('Flatknapp vises med props', () => {
+      const component = wrapper.find(Nav.Flatknapp);
+      expect(component).toHaveLength(1);
+      expect(typeof (component.props().onClick)).toEqual('function');
+      expect(component.props()).toHaveProperty('aria-label', 'Navigasjonslink tilbake til forsiden');
     });
     it('viser StatusLinje med props', () => {
       wrapper.setProps({ opprettetSak: { rinasaksnummer: '6969', url: 'www.www.www' } });
@@ -310,6 +310,15 @@ describe(('Opprettsak Test Suite'), () => {
       const component = (wrapper.find('p'));
       expect(component).toHaveLength(1);
       expect(component.children().text()).toEqual('det brenner');
+    });
+  });
+  describe('Avslutt Modal', () => {
+    it('mountes med korrekte props', () => {
+      wrapper.setState({ visModal: true });
+      const component = (wrapper.find(AvsluttModal));
+      expect(component).toHaveLength(1);
+      expect(component.props()).toHaveProperty('visModal', true);
+      expect(typeof (component.props().closeModal)).toEqual('function');
     });
   });
 
@@ -473,6 +482,18 @@ describe(('Opprettsak Test Suite'), () => {
         expect(settFnrGyldighet).toHaveBeenCalledWith(null);
         expect(settFnrSjekket).toHaveBeenCalledTimes(1);
         expect(settFnrSjekket).toHaveBeenCalledWith(false);
+      });
+    });
+    describe('Modal', () => {
+      it('openModal - setter korrekt state', () => {
+        wrapper.setState({ visModal: false });
+        wrapper.instance().openModal();
+        expect(wrapper.state()).toHaveProperty('visModal', true);
+      });
+      it('closeModal - setter korrekt state', () => {
+        wrapper.setState({ visModal: true });
+        wrapper.instance().closeModal();
+        expect(wrapper.state()).toHaveProperty('visModal', false);
       });
     });
   });


### PR DESCRIPTION
* Rettet opp tester for opprettsak.js
* Laget nye tester for AvsluttModal.js
* Rettet feil i modal som førte til tapt fokus ved keyboardnavigasjon(safari) og testet med skjermleser