### PR TITLE
fix: validate FNR input in vedlegg flow (TEN-1604)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "13.4.0",
+  "version": "13.4.1-TEN-1604-VALIDATE-FNR-VEDLEGG",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "13.4.0",
+      "version": "13.4.1-TEN-1604-VALIDATE-FNR-VEDLEGG",
       "dependencies": {
         "@navikt/aksel-icons": "8.9.0",
         "@navikt/ds-css": "8.9.0",

--- a/package.json
+++ b/package.json
@@ -206,5 +206,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@13.4.1-TEN-1604-VALIDATE-FNR-VEDLEGG"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.4.0",
+  "version": "13.4.1-TEN-1604-VALIDATE-FNR-VEDLEGG",
   "private": true,
   "type": "module",
   "scripts": {
@@ -206,6 +206,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "_id": "neessi@13.4.0",
   "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/src/applications/Vedlegg/Attachments/Attachments.tsx
+++ b/src/applications/Vedlegg/Attachments/Attachments.tsx
@@ -10,6 +10,7 @@ import AttachmentsFromRinaTable from "./AttachmentsFromRinaTable";
 import {Barn, F001Sed, PersonTypeF001, ReplySed} from "../../../declarations/sed";
 import {getFnr} from "../../../utils/fnr";
 import {isFSed} from "../../../utils/sed";
+import {validateFnrDnrNpid} from "../../../utils/fnrValidator";
 
 export interface AttachmentsProps {
   replySed: ReplySed | null | undefined
@@ -46,6 +47,7 @@ const Attachments: React.FC<AttachmentsProps> = ({
 
   const [_fnr, setFnr] = useState<string | undefined>(bFnr ? bFnr : eFnr ? eFnr : aFnr ? aFnr : apFnr ? apFnr : undefined)
   const [_fnrField, setFnrField] = useState<string | undefined>(undefined)
+  const [_fnrError, setFnrError] = useState<string | undefined>(undefined)
 
   const sedAttachmentSorter = (a: JoarkBrowserItem, b: JoarkBrowserItem): number => {
     if (b.type === 'joark' && a.type === 'sed') return -1
@@ -178,7 +180,39 @@ const Attachments: React.FC<AttachmentsProps> = ({
   const fnrSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setFnr(e.currentTarget.value);
     setFnrField("")
+    setFnrError(undefined)
   }
+
+  const FnrTextField = () => (
+    <TextField
+      id='fnr'
+      label={t('label:fnr')}
+      hideLabel={false}
+      error={_fnrError}
+      onChange={(e) => {
+        setFnrField(e.target.value)
+        setFnr(undefined)
+        setFnrError(undefined)
+      }}
+      onBlur={(e) => {
+        const value = e.target.value.trim()
+        if (!value) {
+          setFnr(undefined)
+          setFnrError(undefined)
+          return
+        }
+        const result = validateFnrDnrNpid(value)
+        if (result.status === 'valid') {
+          setFnr(value)
+          setFnrError(undefined)
+        } else {
+          setFnr(undefined)
+          setFnrError(t('validation:invalidFnr'))
+        }
+      }}
+      value={_fnrField}
+    />
+  )
 
   return (
     <Box padding="space-16" borderWidth="1" background="default">
@@ -207,14 +241,7 @@ const Attachments: React.FC<AttachmentsProps> = ({
                 {isFSed(replySed) &&
                   <>
                     <span style={{display: 'flex', alignItems: 'center', paddingTop: '1.5rem'}}>evt.</span>
-                    <TextField
-                      id='fnr'
-                      label={t('label:fnr')}
-                      hideLabel={false}
-                      onChange={(e) => setFnrField(e.target.value)}
-                      onBlur={(e) => setFnr(e.target.value)}
-                      value={_fnrField}
-                    />
+                    <FnrTextField/>
                   </>
                 }
                 <div className='nolabel'>
@@ -246,14 +273,7 @@ const Attachments: React.FC<AttachmentsProps> = ({
                 {isFSed(replySed) &&
                   <>
                     <span style={{display: 'flex', alignItems: 'center', paddingTop: '1.5rem'}}>evt.</span>
-                    <TextField
-                      id='fnr'
-                      label={t('label:fnr')}
-                      hideLabel={false}
-                      onChange={(e) => setFnrField(e.target.value)}
-                      onBlur={(e) => setFnr(e.target.value)}
-                      value={_fnrField}
-                    />
+                    <FnrTextField/>
                   </>
                 }
                 <div className='nolabel'>

--- a/src/applications/Vedlegg/Attachments/Attachments.tsx
+++ b/src/applications/Vedlegg/Attachments/Attachments.tsx
@@ -203,11 +203,11 @@ const Attachments: React.FC<AttachmentsProps> = ({
                   {t('message:warning-no-attachments')}
                 </BodyLong>
               </Box>
-              <HStack gap="space-16">
+              <HStack gap="space-16" align="start">
                 <FNRSelectColumn/>
                 {isFSed(replySed) &&
                   <>
-                    <span style={{display: 'flex', alignItems: 'center', paddingTop: '1.5rem'}}>evt.</span>
+                    <span style={{display: 'flex', alignItems: 'center', paddingTop: '2.5rem'}}>evt.</span>
                     <FnrTextField
                       value={_fnrField}
                       onChange={(raw) => setFnrField(raw)}
@@ -239,11 +239,11 @@ const Attachments: React.FC<AttachmentsProps> = ({
                 tableId='vedlegg-view'
                 onUpdateAttachmentSensitivt={onUpdateAttachmentSensitivt}
               />
-              <HStack gap="space-16">
+              <HStack gap="space-16" align="start">
                 <FNRSelectColumn/>
                 {isFSed(replySed) &&
                   <>
-                    <span style={{display: 'flex', alignItems: 'center', paddingTop: '1.5rem'}}>evt.</span>
+                    <span style={{display: 'flex', alignItems: 'center', paddingTop: '2.5rem'}}>evt.</span>
                     <FnrTextField
                       value={_fnrField}
                       onChange={(raw) => setFnrField(raw)}

--- a/src/applications/Vedlegg/Attachments/Attachments.tsx
+++ b/src/applications/Vedlegg/Attachments/Attachments.tsx
@@ -1,6 +1,7 @@
-import {BodyLong, Box, Button, Heading, HStack, Select, TextField, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HStack, Select, VStack} from '@navikt/ds-react'
 import { JoarkBrowser } from 'applications/Vedlegg/JoarkBrowser/JoarkBrowser'
 import SEDAttachmentModal from 'applications/Vedlegg/SEDAttachmentModal/SEDAttachmentModal'
+import FnrTextField from 'components/FnrTextField/FnrTextField'
 import { JoarkBrowserItem, JoarkBrowserItems } from 'declarations/attachments'
 import _ from 'lodash'
 import React, {useEffect, useState} from 'react'
@@ -10,7 +11,6 @@ import AttachmentsFromRinaTable from "./AttachmentsFromRinaTable";
 import {Barn, F001Sed, PersonTypeF001, ReplySed} from "../../../declarations/sed";
 import {getFnr} from "../../../utils/fnr";
 import {isFSed} from "../../../utils/sed";
-import {validateFnrDnrNpid} from "../../../utils/fnrValidator";
 
 export interface AttachmentsProps {
   replySed: ReplySed | null | undefined
@@ -47,7 +47,6 @@ const Attachments: React.FC<AttachmentsProps> = ({
 
   const [_fnr, setFnr] = useState<string | undefined>(bFnr ? bFnr : eFnr ? eFnr : aFnr ? aFnr : apFnr ? apFnr : undefined)
   const [_fnrField, setFnrField] = useState<string | undefined>(undefined)
-  const [_fnrError, setFnrError] = useState<string | undefined>(undefined)
 
   const sedAttachmentSorter = (a: JoarkBrowserItem, b: JoarkBrowserItem): number => {
     if (b.type === 'joark' && a.type === 'sed') return -1
@@ -180,39 +179,7 @@ const Attachments: React.FC<AttachmentsProps> = ({
   const fnrSelect = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setFnr(e.currentTarget.value);
     setFnrField("")
-    setFnrError(undefined)
   }
-
-  const FnrTextField = () => (
-    <TextField
-      id='fnr'
-      label={t('label:fnr')}
-      hideLabel={false}
-      error={_fnrError}
-      onChange={(e) => {
-        setFnrField(e.target.value)
-        setFnr(undefined)
-        setFnrError(undefined)
-      }}
-      onBlur={(e) => {
-        const value = e.target.value.trim()
-        if (!value) {
-          setFnr(undefined)
-          setFnrError(undefined)
-          return
-        }
-        const result = validateFnrDnrNpid(value)
-        if (result.status === 'valid') {
-          setFnr(value)
-          setFnrError(undefined)
-        } else {
-          setFnr(undefined)
-          setFnrError(t('validation:invalidFnr'))
-        }
-      }}
-      value={_fnrField}
-    />
-  )
 
   return (
     <Box padding="space-16" borderWidth="1" background="default">
@@ -241,7 +208,11 @@ const Attachments: React.FC<AttachmentsProps> = ({
                 {isFSed(replySed) &&
                   <>
                     <span style={{display: 'flex', alignItems: 'center', paddingTop: '1.5rem'}}>evt.</span>
-                    <FnrTextField/>
+                    <FnrTextField
+                      value={_fnrField}
+                      onChange={(raw) => setFnrField(raw)}
+                      onValidFnr={setFnr}
+                    />
                   </>
                 }
                 <div className='nolabel'>
@@ -273,7 +244,11 @@ const Attachments: React.FC<AttachmentsProps> = ({
                 {isFSed(replySed) &&
                   <>
                     <span style={{display: 'flex', alignItems: 'center', paddingTop: '1.5rem'}}>evt.</span>
-                    <FnrTextField/>
+                    <FnrTextField
+                      value={_fnrField}
+                      onChange={(raw) => setFnrField(raw)}
+                      onValidFnr={setFnr}
+                    />
                   </>
                 }
                 <div className='nolabel'>

--- a/src/applications/Vedlegg/JoarkBrowser/JoarkBrowser.tsx
+++ b/src/applications/Vedlegg/JoarkBrowser/JoarkBrowser.tsx
@@ -319,7 +319,7 @@ export const JoarkBrowser: React.FC<JoarkBrowserProps> = ({
   }, [existingItems, list, mode])
 
   useEffect(() => {
-    if (mode === "select" && fnr && !gettingJoarkList) {
+    if (mode === "select" && fnr && /^\d{11}$/.test(fnr) && !gettingJoarkList) {
       dispatch(listJoarkItems(fnr, ''))
     }
   }, [fnr])

--- a/src/components/FnrTextField/FnrTextField.tsx
+++ b/src/components/FnrTextField/FnrTextField.tsx
@@ -1,0 +1,64 @@
+import { TextField } from '@navikt/ds-react'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { validateFnrDnrNpid } from 'utils/fnrValidator'
+
+export interface FnrTextFieldProps {
+  id?: string
+  label?: string
+  hideLabel?: boolean
+  value: string | undefined
+  onChange: (raw: string) => void
+  onValidFnr: (fnr: string | undefined) => void
+  error?: string
+}
+
+const FnrTextField: React.FC<FnrTextFieldProps> = ({
+  id = 'fnr',
+  label,
+  hideLabel = false,
+  value,
+  onChange,
+  onValidFnr,
+  error: externalError
+}: FnrTextFieldProps): JSX.Element => {
+  const { t } = useTranslation()
+  const [_error, setError] = useState<string | undefined>(undefined)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value)
+    onValidFnr(undefined)
+    setError(undefined)
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const trimmed = e.target.value.trim()
+    if (!trimmed) {
+      onValidFnr(undefined)
+      setError(undefined)
+      return
+    }
+    const result = validateFnrDnrNpid(trimmed)
+    if (result.status === 'valid') {
+      onValidFnr(trimmed)
+      setError(undefined)
+    } else {
+      onValidFnr(undefined)
+      setError(t('validation:invalidFnr'))
+    }
+  }
+
+  return (
+    <TextField
+      id={id}
+      label={label ?? t('label:fnr')}
+      hideLabel={hideLabel}
+      error={externalError ?? _error}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      value={value}
+    />
+  )
+}
+
+export default FnrTextField

--- a/src/pages/Vedlegg/Vedlegg.tsx
+++ b/src/pages/Vedlegg/Vedlegg.tsx
@@ -19,6 +19,7 @@ import {JoarkBrowserItem, JoarkBrowserItems} from "declarations/attachments";
 import JoarkBrowser from "applications/Vedlegg/JoarkBrowser/JoarkBrowser";
 import {alertReset} from "actions/alert";
 import {propertySet, resetVedlegg} from "actions/vedlegg";
+import {validateFnrDnrNpid} from "utils/fnrValidator";
 
 export interface VedleggSelector {
   alertMessage: JSX.Element | string | undefined
@@ -45,17 +46,36 @@ const Vedlegg: React.FC = (): JSX.Element => {
   const { alertMessage, alertType, rinasaksnummer, rinadokumentID, vedleggResponse, validation }: VedleggSelector = useAppSelector(mapState)
 
   const [_fnr, setFnr] = useState<string | undefined>(undefined)
+  const [_fnrField, setFnrField] = useState<string>('')
+  const [_fnrError, setFnrError] = useState<string | undefined>(undefined)
   const [_attachmentsTableVisible, setAttachmentsTableVisible] = useState<boolean>(false)
   const [_items, setItems] = useState<JoarkBrowserItems>([])
   const [_viewSendVedleggModal, setViewSendVedleggModal] = useState<boolean>(false)
 
+  const validateAndSetFnr = (value: string) => {
+    if (!value || value.trim() === '') {
+      setFnr(undefined)
+      setFnrError(undefined)
+      return
+    }
+    const trimmed = value.trim()
+    const result = validateFnrDnrNpid(trimmed)
+    if (result.status === 'valid') {
+      setFnr(trimmed)
+      setFnrError(undefined)
+    } else {
+      setFnr(undefined)
+      setFnrError(t('validation:invalidFnr'))
+    }
+  }
 
   useEffect(() => {
     const params: URLSearchParams = new URLSearchParams(window.location.search)
     const rinasaksnummer = params.get('rinasaksnummer')
     const fnr = params.get('fnr')
     if(fnr){
-      setFnr(fnr)
+      setFnrField(fnr)
+      validateAndSetFnr(fnr)
     }
     if (rinasaksnummer) {
       dispatch(vedleggActions.propertySet('rinasaksnummer', rinasaksnummer))
@@ -110,7 +130,9 @@ const Vedlegg: React.FC = (): JSX.Element => {
   }
 
   const resetAndClose = () => {
-    setFnr("")
+    setFnrField('')
+    setFnr(undefined)
+    setFnrError(undefined)
     setItems([])
     dispatch(alertReset())
     dispatch(resetVedlegg())
@@ -145,15 +167,20 @@ const Vedlegg: React.FC = (): JSX.Element => {
               <HGrid columns={2} gap="space-16" align="start">
                 <TextField
                   id="fnr"
-                  error={validation[namespace + '-fnr']?.feilmelding}
+                  error={_fnrError ?? validation[namespace + '-fnr']?.feilmelding}
                   label="Fødselsnummer"
-                  onChange={(e) => setFnr(e.target.value)}
-                  value={_fnr}
+                  onChange={(e) => {
+                    setFnrField(e.target.value)
+                    setFnr(undefined)
+                    setFnrError(undefined)
+                  }}
+                  onBlur={(e) => validateAndSetFnr(e.target.value)}
+                  value={_fnrField}
                 />
                 <div className='nolabel'>
                   <Button
                     variant='secondary'
-                    disabled={_.isNil(_fnr) || _fnr === ''}
+                    disabled={!_fnr}
                     onClick={() => {
                       setAttachmentsTableVisible(!_attachmentsTableVisible)
                     }}

--- a/src/pages/Vedlegg/Vedlegg.tsx
+++ b/src/pages/Vedlegg/Vedlegg.tsx
@@ -1,9 +1,10 @@
-import {Alert, Box, Button, HGrid, HStack, Link, Page, Spacer, TextField, VStack} from '@navikt/ds-react'
+import {Alert, Box, Button, HGrid, HStack, Link, Page, Spacer, VStack} from '@navikt/ds-react'
 import { resetValidation, setValidation } from 'actions/validation'
 import * as vedleggActions from 'actions/vedlegg'
 import DocumentSearch from 'applications/Vedlegg/DocumentSearch/DocumentSearch'
 import TopContainer from 'components/TopContainer/TopContainer'
 import ValidationBox from 'components/ValidationBox/ValidationBox'
+import FnrTextField from 'components/FnrTextField/FnrTextField'
 import * as types from 'constants/actionTypes'
 import { State } from 'declarations/reducers'
 import { Validation, VedleggSendResponse } from 'declarations/types'
@@ -47,27 +48,9 @@ const Vedlegg: React.FC = (): JSX.Element => {
 
   const [_fnr, setFnr] = useState<string | undefined>(undefined)
   const [_fnrField, setFnrField] = useState<string>('')
-  const [_fnrError, setFnrError] = useState<string | undefined>(undefined)
   const [_attachmentsTableVisible, setAttachmentsTableVisible] = useState<boolean>(false)
   const [_items, setItems] = useState<JoarkBrowserItems>([])
   const [_viewSendVedleggModal, setViewSendVedleggModal] = useState<boolean>(false)
-
-  const validateAndSetFnr = (value: string) => {
-    if (!value || value.trim() === '') {
-      setFnr(undefined)
-      setFnrError(undefined)
-      return
-    }
-    const trimmed = value.trim()
-    const result = validateFnrDnrNpid(trimmed)
-    if (result.status === 'valid') {
-      setFnr(trimmed)
-      setFnrError(undefined)
-    } else {
-      setFnr(undefined)
-      setFnrError(t('validation:invalidFnr'))
-    }
-  }
 
   useEffect(() => {
     const params: URLSearchParams = new URLSearchParams(window.location.search)
@@ -75,7 +58,10 @@ const Vedlegg: React.FC = (): JSX.Element => {
     const fnr = params.get('fnr')
     if(fnr){
       setFnrField(fnr)
-      validateAndSetFnr(fnr)
+      const result = validateFnrDnrNpid(fnr.trim())
+      if (result.status === 'valid') {
+        setFnr(fnr.trim())
+      }
     }
     if (rinasaksnummer) {
       dispatch(vedleggActions.propertySet('rinasaksnummer', rinasaksnummer))
@@ -132,7 +118,6 @@ const Vedlegg: React.FC = (): JSX.Element => {
   const resetAndClose = () => {
     setFnrField('')
     setFnr(undefined)
-    setFnrError(undefined)
     setItems([])
     dispatch(alertReset())
     dispatch(resetVedlegg())
@@ -165,17 +150,12 @@ const Vedlegg: React.FC = (): JSX.Element => {
             <Spacer/>
             <VStack paddingBlock="space-48" width="50%" gap="space-16">
               <HGrid columns={2} gap="space-16" align="start">
-                <TextField
-                  id="fnr"
-                  error={_fnrError ?? validation[namespace + '-fnr']?.feilmelding}
+                <FnrTextField
                   label="Fødselsnummer"
-                  onChange={(e) => {
-                    setFnrField(e.target.value)
-                    setFnr(undefined)
-                    setFnrError(undefined)
-                  }}
-                  onBlur={(e) => validateAndSetFnr(e.target.value)}
                   value={_fnrField}
+                  onChange={setFnrField}
+                  onValidFnr={setFnr}
+                  error={validation[namespace + '-fnr']?.feilmelding}
                 />
                 <div className='nolabel'>
                   <Button


### PR DESCRIPTION
Resolves [TEN-1604](https://nav.atlassian.net/browse/TEN-1604)

## Changes
- **Vedlegg.tsx** (forside flow): Split FNR into raw input (`_fnrField`) and validated (`_fnr`) state. Validate with `validateFnrDnrNpid` on blur. Show error on invalid input. Also validate FNR from URL query params.
- **Attachments.tsx** (SED flow): Add FNR validation on the manual TextField onBlur. Extract shared `FnrTextField` component to avoid duplication. Clear error on select dropdown change.
- **JoarkBrowser.tsx**: Defense-in-depth guard — only dispatch `listJoarkItems` when FNR matches 11-digit pattern.

## Verification
- TypeScript typecheck passes
- Full vite build succeeds
- Invalid FNR (e.g. `NO 23456789 / 3456873458`) is rejected at the input level before any API call