### PR TITLE
fix: guard against undefined rinaDokumentId in attachment sending (TEN-1603)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "13.4.1-TEN-1604-VALIDATE-FNR-VEDLEGG",
+  "version": "13.4.2-TEN-1603-UNDEFINED-RINADOKUMENTID",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "13.4.1-TEN-1604-VALIDATE-FNR-VEDLEGG",
+      "version": "13.4.2-TEN-1603-UNDEFINED-RINADOKUMENTID",
       "dependencies": {
         "@navikt/aksel-icons": "8.9.0",
         "@navikt/ds-css": "8.9.0",

--- a/package.json
+++ b/package.json
@@ -206,5 +206,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@13.4.2-TEN-1603-UNDEFINED-RINADOKUMENTID"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.4.1",
+  "version": "13.4.2-TEN-1603-UNDEFINED-RINADOKUMENTID",
   "private": true,
   "type": "module",
   "scripts": {
@@ -206,6 +206,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@13.4.1"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/public/locales/nb/message.json
+++ b/public/locales/nb/message.json
@@ -81,6 +81,7 @@
   "warning-no-address": "Ingen adresser er registrert",
   "warning-no-arbeidsgiver-found": "Ingen arbeidsperioder funnet",
   "warning-no-attachments": "Ingen vedlegg er valgt",
+  "warning-x-attachments-skipped-missing-dokument-id": "{{skipped}} vedlegg ble ikke sendt (mangler dokument-ID):",
   "warning-no-barn": "Ingen barn",
   "warning-no-email": "Ingen e-post adresser",
   "warning-no-dokument": "Ingen dokumenter",

--- a/src/actions/attachments.ts
+++ b/src/actions/attachments.ts
@@ -64,6 +64,13 @@ export const resetSedAttachments: ActionCreator<Action> = (): Action => ({
 export const sendAttachmentToSed = (
   params: SEDAttachmentPayloadWithFile, joarkBrowserItem: JoarkBrowserItem
 ): Action => {
+  if (!params.rinaDokumentId) {
+    return {
+      type: types.ATTACHMENT_SEND_FAILURE,
+      error: 'rinaDokumentId is undefined — cannot send attachment'
+    } as unknown as Action
+  }
+
   params = {
     ...params,
     filnavn: encodeURIComponent(params.filnavn)

--- a/src/applications/SvarSed/SendSEDModal/SendSEDModal.tsx
+++ b/src/applications/SvarSed/SendSEDModal/SendSEDModal.tsx
@@ -15,7 +15,7 @@ import { State } from 'declarations/reducers'
 import { ReplySed } from 'declarations/sed'
 import { CreateSedResponse } from 'declarations/types'
 import _ from 'lodash'
-import {Alert, Box, Button, HStack, Loader, Spacer, VStack} from '@navikt/ds-react'
+import {Alert, Box, Button, HStack, List, Loader, Spacer, VStack} from '@navikt/ds-react'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
@@ -81,6 +81,7 @@ const SendSEDModal: React.FC<SendSEDModalProps> = ({
   const [_sedSent, setSedSent] = useState<boolean>(false)
   const [_finished, setFinished] = useState<string | undefined>(undefined)
   const [_sendButtonClicked, _setSendButtonClicked] = useState<boolean>(false)
+  const [_skippedAttachments, setSkippedAttachments] = useState<JoarkBrowserItems>([])
 
   const sedAttachmentSorter = (a: JoarkBrowserItem, b: JoarkBrowserItem): number => {
     if (b.type === 'joark' && a.type === 'sed') return -1
@@ -158,6 +159,13 @@ const SendSEDModal: React.FC<SendSEDModalProps> = ({
         _onFinished(t('message:success-no-attachments-to-save'))
         return
       }
+
+      if (!sedCreatedResponse?.sedId) {
+        setSkippedAttachments(joarksToUpload)
+        _onFinished(t('message:warning-x-attachments-skipped-missing-dokument-id', { skipped: joarksToUpload.length }))
+        return
+      }
+
       // attachments to send -> start a savingAttachmentsJob
       setSendingAttachments(true)
       dispatch(createSavingAttachmentJob(joarksToUpload))
@@ -270,6 +278,16 @@ const SendSEDModal: React.FC<SendSEDModalProps> = ({
                       </HStack>
                     )}
                   </div>
+                  {!_.isEmpty(_skippedAttachments) && (
+                    <Alert variant='warning' size='small'>
+                      {t('message:warning-x-attachments-skipped-missing-dokument-id', { skipped: _skippedAttachments.length })}
+                      <List size='small'>
+                        {_skippedAttachments.map((att) => (
+                          <List.Item key={att.key}>{att.title}</List.Item>
+                        ))}
+                      </List>
+                    </Alert>
+                  )}
                 </VStack>
               </HStack>
               <HStack justify="center" align="stretch">

--- a/src/applications/Vedlegg/SendAttachmentModal/SendAttachmentModal.tsx
+++ b/src/applications/Vedlegg/SendAttachmentModal/SendAttachmentModal.tsx
@@ -14,7 +14,7 @@ import {createSavingAttachmentJob, resetSedAttachments, sendAttachmentToSed} fro
 import {useTranslation} from "react-i18next";
 import {alertReset} from "../../../actions/alert";
 import SEDAttachmentSender from "../SEDAttachmentSender/SEDAttachmentSender";
-import {Alert, Box, Button, HStack, VStack} from "@navikt/ds-react";
+import {Alert, Box, Button, HStack, List, VStack} from "@navikt/ds-react";
 import * as types from "../../../constants/actionTypes";
 import {CheckmarkCircleFillIcon} from "@navikt/aksel-icons";
 
@@ -66,6 +66,7 @@ const SendAttachmentModal: React.FC<SendAttachmentModalProps> = ({
   const [_attachmentsSent, setAttachmentsSent] = useState<boolean>(false)
   const [_sendingAttachments, setSendingAttachments] = useState<boolean>(initialSendingAttachments)
   const [_finished, setFinished] = useState<string | undefined>(undefined)
+  const [_skippedAttachments, setSkippedAttachments] = useState<JoarkBrowserItems>([])
 
   const sedAttachmentSorter = (a: JoarkBrowserItem, b: JoarkBrowserItem): number => {
     if (b.type === 'joark' && a.type === 'sed') return -1
@@ -120,6 +121,13 @@ const SendAttachmentModal: React.FC<SendAttachmentModalProps> = ({
         _onFinished(t('message:success-no-attachments-to-save'))
         return
       }
+
+      if (!rinaDokumentId) {
+        setSkippedAttachments(joarksToUpload)
+        _onFinished(t('message:warning-x-attachments-skipped-missing-dokument-id', { skipped: joarksToUpload.length }))
+        return
+      }
+
       // attachments to send -> start a savingAttachmentsJob
       setSendingAttachments(true)
       dispatch(createSavingAttachmentJob(joarksToUpload))
@@ -178,6 +186,16 @@ const SendAttachmentModal: React.FC<SendAttachmentModalProps> = ({
                   <CheckmarkCircleFillIcon color='var(--ax-bg-success-strong)' />
                   <span>{_finished}</span>
                 </HStack>
+                {!_.isEmpty(_skippedAttachments) && (
+                  <Alert variant='warning' size='small'>
+                    {t('message:warning-x-attachments-skipped-missing-dokument-id', { skipped: _skippedAttachments.length })}
+                    <List size='small'>
+                      {_skippedAttachments.map((att) => (
+                        <List.Item key={att.key}>{att.title}</List.Item>
+                      ))}
+                    </List>
+                  </Alert>
+                )}
                 <HStack gap="space-8" align="center" justify="center">
                   <Button
                     variant='secondary'


### PR DESCRIPTION
Resolves [TEN-1603](https://jira.adeo.no/browse/TEN-1603)

## Changes
- **SendSEDModal**: When `sedCreatedResponse?.sedId` is falsy, all joark attachments are skipped instead of being sent with "undefined" in the URL. Skipped attachments are listed in a warning Alert.
- **SendAttachmentModal**: Same skip-and-warn pattern when `rinaDokumentId` is undefined (defense-in-depth; the Vedlegg page already validates this).
- **`sendAttachmentToSed()` action**: Added defensive guard — returns a failure action immediately if `rinaDokumentId` is missing, preventing "undefined" from ever appearing in the URL.
- **Translation**: Added `warning-x-attachments-skipped-missing-dokument-id` key.

## Verification
- TypeScript typecheck passes
- Full Vite build succeeds
- Existing attachment action tests pass (6/6)