### PR TITLE
Pin @navikt/ds-react to 8.9.0 to avoid radio className regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@navikt/aksel-icons": "8.9.1",
         "@navikt/ds-css": "8.9.1",
-        "@navikt/ds-react": "8.9.1",
+        "@navikt/ds-react": "8.9.0",
         "@navikt/eessi-kodeverk": "2.4.1",
         "@navikt/fetch": "7.2.11",
         "@navikt/flagg-ikoner": "13.0.7",
@@ -2916,16 +2916,16 @@
       "peer": true
     },
     "node_modules/@navikt/ds-react": {
-      "version": "8.9.1",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/8.9.1/a9dfd4b309cee1dc078b6d43b5ec791d238e16fe",
-      "integrity": "sha512-TG9AWjQMtHj1ORibdXmtbIFTsg17fBTYHSOI75SUA+zLcG0SSpFAbkn7Ltc6wpc6oDAH46vNJJh8ky5F3YHjPQ==",
+      "version": "8.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/8.9.0/702b26c818eee38d01777e541e5e419c314a0d60",
+      "integrity": "sha512-FJd+LvVQbdWWocIdc6POWuXRAeBCOmEQY4kAiKT+sZl1TX48YF6DP9aqg65U+EAio2ZA8T9q64VBOoGWe3CjXQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@floating-ui/react": "0.27.8",
         "@floating-ui/react-dom": "^2.1.8",
-        "@navikt/aksel-icons": "^8.9.1",
-        "@navikt/ds-tokens": "^8.9.1",
+        "@navikt/aksel-icons": "^8.9.0",
+        "@navikt/ds-tokens": "^8.9.0",
         "date-fns": "^4.0.0",
         "react-day-picker": "9.7.0"
       },
@@ -19387,15 +19387,15 @@
       "peer": true
     },
     "@navikt/ds-react": {
-      "version": "8.9.1",
-      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/8.9.1/a9dfd4b309cee1dc078b6d43b5ec791d238e16fe",
-      "integrity": "sha512-TG9AWjQMtHj1ORibdXmtbIFTsg17fBTYHSOI75SUA+zLcG0SSpFAbkn7Ltc6wpc6oDAH46vNJJh8ky5F3YHjPQ==",
+      "version": "8.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@navikt/ds-react/8.9.0/702b26c818eee38d01777e541e5e419c314a0d60",
+      "integrity": "sha512-FJd+LvVQbdWWocIdc6POWuXRAeBCOmEQY4kAiKT+sZl1TX48YF6DP9aqg65U+EAio2ZA8T9q64VBOoGWe3CjXQ==",
       "peer": true,
       "requires": {
         "@floating-ui/react": "0.27.8",
         "@floating-ui/react-dom": "^2.1.8",
-        "@navikt/aksel-icons": "^8.9.1",
-        "@navikt/ds-tokens": "^8.9.1",
+        "@navikt/aksel-icons": "^8.9.0",
+        "@navikt/ds-tokens": "^8.9.0",
         "date-fns": "^4.0.0",
         "react-day-picker": "9.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@navikt/aksel-icons": "8.9.1",
     "@navikt/ds-css": "8.9.1",
-    "@navikt/ds-react": "8.9.1",
+    "@navikt/ds-react": "8.9.0",
     "@navikt/eessi-kodeverk": "2.4.1",
     "@navikt/fetch": "7.2.11",
     "@navikt/flagg-ikoner": "13.0.7",


### PR DESCRIPTION
In 8.9.1 the Radio component spreads user props (including className) onto
the underlying <input> element, causing className-based styles like
commonStyles.radioPanel to also apply to the radio input itself. This
breaks the visual appearance of the radio (square, stretched, padded
instead of a circular indicator).

Reverting to 8.9.0 until the upstream regression is fixed.

Tracking issue: filed at navikt/aksel.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
