### PR TITLE
fix: introduce RadioPanel wrapper to restore styling under Aksel 8.9.1 (TEN-1658)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "13.4.3",
+  "version": "13.5.0-FIX-TEN-1658-RADIOPANEL-WRAPPER",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "13.4.3",
+      "version": "13.5.0-FIX-TEN-1658-RADIOPANEL-WRAPPER",
       "dependencies": {
         "@navikt/aksel-icons": "8.9.0",
         "@navikt/ds-css": "8.9.0",

--- a/package.json
+++ b/package.json
@@ -206,5 +206,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@13.5.0-FIX-TEN-1658-RADIOPANEL-WRAPPER"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.4.4",
+  "version": "13.5.0-FIX-TEN-1658-RADIOPANEL-WRAPPER",
   "private": true,
   "type": "module",
   "scripts": {
@@ -206,6 +206,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@13.4.4"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.5.0-FIX-TEN-1658-RADIOPANEL-WRAPPER",
+  "version": "13.5.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -207,5 +207,5 @@
   ],
   "readme": "ERROR: No README data found!",
   "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@13.5.0-FIX-TEN-1658-RADIOPANEL-WRAPPER"
+  "_id": "neessi@13.5.0"
 }

--- a/src/applications/PDU1/Person/Person.tsx
+++ b/src/applications/PDU1/Person/Person.tsx
@@ -1,4 +1,5 @@
-import {Alert, BodyLong, Box, Heading, HGrid, HStack, Radio, RadioGroup, VStack} from '@navikt/ds-react'
+import {Alert, BodyLong, Box, Heading, HGrid, HStack, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { setReplySed } from 'actions/svarsed'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validatePerson, ValidationPersonProps } from 'applications/PDU1/Person/validation'
@@ -17,8 +18,6 @@ import performValidation from 'utils/performValidation'
 import Adresse from './Adresse/Adresse'
 import StatsborgerskapFC from './Statsborgerskap/Statsborgerskap'
 import DateField from "../../../components/DateField/DateField";
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -135,12 +134,12 @@ const Person: React.FC<MainFormProps> = ({
           onChange={onKjoennChange}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='K'>
+            <RadioPanel value='K'>
               {t('label:kvinne')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel} value='M'>
+            </RadioPanel>
+            <RadioPanel value='M'>
               {t('label:mann')}
-            </Radio>
+            </RadioPanel>
           </HStack>
         </RadioGroup>
         </HGrid>

--- a/src/applications/PDU1/Person/Person.tsx
+++ b/src/applications/PDU1/Person/Person.tsx
@@ -1,5 +1,5 @@
 import {Alert, BodyLong, Box, Heading, HGrid, HStack, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { setReplySed } from 'actions/svarsed'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validatePerson, ValidationPersonProps } from 'applications/PDU1/Person/validation'

--- a/src/applications/SvarSed/AddPersonModal/AddPersonModal.tsx
+++ b/src/applications/SvarSed/AddPersonModal/AddPersonModal.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon, ChildEyesIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Heading, HStack, Modal as NavModal, Radio, RadioGroup, Spacer, TextField, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HStack, Modal as NavModal, RadioGroup, Spacer, TextField, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { ActionWithPayload } from '@navikt/fetch'
 import { validateAddPersonModal, ValidationAddPersonModalProps } from 'applications/SvarSed/AddPersonModal/validation'
 import AddRemovePanel from 'components/AddRemovePanel/AddRemovePanel'
@@ -340,15 +341,15 @@ const AddPersonModal = <T extends StorageTypes>({
                   onChange={setKjoenn}
                 >
                   <HStack gap="space-8">
-                    <Radio value='M' className={commonStyles.radioPanel}>
+                    <RadioPanel value='M'>
                       {t(_newPersonRelation?.startsWith('barn') ? 'label:gutt' : 'label:mann')}
-                    </Radio>
-                    <Radio value='K' className={commonStyles.radioPanel}>
+                    </RadioPanel>
+                    <RadioPanel value='K'>
                       {t(_newPersonRelation?.startsWith('barn') ? 'label:jente' : 'label:kvinne')}
-                    </Radio>
-                    <Radio value='U' className={commonStyles.radioPanel}>
+                    </RadioPanel>
+                    <RadioPanel value='U'>
                       {t('label:ukjent')}
-                    </Radio>
+                    </RadioPanel>
                   </HStack>
                 </RadioGroup>
                 <Select

--- a/src/applications/SvarSed/AddPersonModal/AddPersonModal.tsx
+++ b/src/applications/SvarSed/AddPersonModal/AddPersonModal.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon, ChildEyesIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HStack, Modal as NavModal, RadioGroup, Spacer, TextField, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { ActionWithPayload } from '@navikt/fetch'
 import { validateAddPersonModal, ValidationAddPersonModalProps } from 'applications/SvarSed/AddPersonModal/validation'
 import AddRemovePanel from 'components/AddRemovePanel/AddRemovePanel'

--- a/src/applications/SvarSed/Adresser/AdresseForm.tsx
+++ b/src/applications/SvarSed/Adresser/AdresseForm.tsx
@@ -6,9 +6,8 @@ import _ from 'lodash'
 import React, {useEffect} from 'react'
 import { useTranslation } from 'react-i18next'
 import CountryDropdown from "components/CountryDropdown/CountryDropdown";
-import {HGrid, HStack, Radio, RadioGroup, VStack} from "@navikt/ds-react";
-import commonStyles from 'assets/css/common.module.css'
-
+import {HGrid, HStack, RadioGroup, VStack} from "@navikt/ds-react";
+import RadioPanel from 'components/RadioPanel'
 export interface AdresseFormProps {
   disabled?: boolean
   options?: {[k in string]: any}
@@ -114,9 +113,9 @@ const AdresseForm: React.FC<AdresseFormProps> = ({
           onChange={(e: string) => setType((e as AdresseType))}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='bosted'>{t('label:bosted')}</Radio>
-            <Radio className={commonStyles.radioPanel} value='opphold'>{t('label:opphold')}</Radio>
-            <Radio className={commonStyles.radioPanel} value='kontakt'>{t('label:kontakt')}</Radio>
+            <RadioPanel value='bosted'>{t('label:bosted')}</RadioPanel>
+            <RadioPanel value='opphold'>{t('label:opphold')}</RadioPanel>
+            <RadioPanel value='kontakt'>{t('label:kontakt')}</RadioPanel>
           </HStack>
         </RadioGroup>
       )}

--- a/src/applications/SvarSed/Adresser/AdresseForm.tsx
+++ b/src/applications/SvarSed/Adresser/AdresseForm.tsx
@@ -7,7 +7,7 @@ import React, {useEffect} from 'react'
 import { useTranslation } from 'react-i18next'
 import CountryDropdown from "components/CountryDropdown/CountryDropdown";
 import {HGrid, HStack, RadioGroup, VStack} from "@navikt/ds-react";
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 export interface AdresseFormProps {
   disabled?: boolean
   options?: {[k in string]: any}

--- a/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
+++ b/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
@@ -1,5 +1,5 @@
 import {Box, HGrid, Heading, HStack, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateAnmodningInfo, ValidationAnmodningInfoProps } from 'applications/SvarSed/AnmodningInfo/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
+++ b/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
@@ -1,4 +1,5 @@
-import { Box, HGrid, Heading, HStack, Radio, RadioGroup, VStack } from '@navikt/ds-react'
+import {Box, HGrid, Heading, HStack, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateAnmodningInfo, ValidationAnmodningInfoProps } from 'applications/SvarSed/AnmodningInfo/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -13,8 +14,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -103,12 +102,12 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
           onChange={setGjelderArbeidsufoerhet}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='ja'>
+            <RadioPanel value='ja'>
               {t('label:ja')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel} value='nei'>
+            </RadioPanel>
+            <RadioPanel value='nei'>
               {t('label:nei')}
-            </Radio>
+            </RadioPanel>
           </HStack>
         </RadioGroup>
 

--- a/src/applications/SvarSed/AnmodningsPeriode/AnmodningsPeriode.tsx
+++ b/src/applications/SvarSed/AnmodningsPeriode/AnmodningsPeriode.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector, mapState } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'

--- a/src/applications/SvarSed/AnmodningsPeriode/AnmodningsPeriode.tsx
+++ b/src/applications/SvarSed/AnmodningsPeriode/AnmodningsPeriode.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Heading, HGrid, HStack, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HGrid, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector, mapState } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -260,12 +261,12 @@ const AnmodningsPeriode: React.FC<MainFormProps> = ({
               onChange={(e: string | number | boolean) => setKravType(e as string)}
               value={(replySed as F002Sed).krav?.kravType}
             >
-              <Radio className={commonStyles.radioPanel} value='nytt_krav'>
+              <RadioPanel value='nytt_krav'>
                 {t('label:kravType-nytt_krav')}
-              </Radio>
-              <Radio className={commonStyles.radioPanel} value='endrede_omstendigheter'>
+              </RadioPanel>
+              <RadioPanel value='endrede_omstendigheter'>
                 {t('label:kravType-endrede_omstendigheter')}
-              </Radio>
+              </RadioPanel>
             </RadioGroup>
             <DateField
               error={validation[namespace + '-kravMottattDato']?.feilmelding}
@@ -285,12 +286,12 @@ const AnmodningsPeriode: React.FC<MainFormProps> = ({
               value={(replySed as F002Sed).krav?.infoType}
               onChange={(e: string | number | boolean) => setInfoType(e as string)}
             >
-              <Radio className={commonStyles.radioPanel} value='bekrefter_opplysninger'>
+              <RadioPanel value='bekrefter_opplysninger'>
                 {t('label:info-confirm-information')}
-              </Radio>
-              <Radio className={commonStyles.radioPanel} value='gi_oss_opplysninger'>
+              </RadioPanel>
+              <RadioPanel value='gi_oss_opplysninger'>
                 {t('label:info-point-information')}
-              </Radio>
+              </RadioPanel>
             </RadioGroup>
             {(replySed as F002Sed).krav?.infoType === 'gi_oss_opplysninger' && (
               <TextArea

--- a/src/applications/SvarSed/Avslutning/Avslutning.tsx
+++ b/src/applications/SvarSed/Avslutning/Avslutning.tsx
@@ -1,4 +1,5 @@
-import {Box, Heading, HStack, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {Box, Heading, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateAvslutning, ValidationAvslutningProps } from 'applications/SvarSed/Avslutning/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -14,8 +15,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
-import commonStyles from "assets/css/common.module.css"
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -121,12 +120,12 @@ const Avslutning: React.FC<MainFormProps> = ({
           onChange={setAvslutningType}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='manuell'>
+            <RadioPanel value='manuell'>
               {t('label:manuell')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel} value='automatisk'>
+            </RadioPanel>
+            <RadioPanel value='automatisk'>
               {t('label:automatisk')}
-            </Radio>
+            </RadioPanel>
             <Spacer/>
             <Spacer/>
           </HStack>

--- a/src/applications/SvarSed/Avslutning/Avslutning.tsx
+++ b/src/applications/SvarSed/Avslutning/Avslutning.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateAvslutning, ValidationAvslutningProps } from 'applications/SvarSed/Avslutning/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/applications/SvarSed/Avvis/Avvis.tsx
+++ b/src/applications/SvarSed/Avvis/Avvis.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import Input from 'components/Forms/Input'

--- a/src/applications/SvarSed/Avvis/Avvis.tsx
+++ b/src/applications/SvarSed/Avvis/Avvis.tsx
@@ -1,4 +1,5 @@
-import {Box, Heading, Radio, RadioGroup, VStack} from '@navikt/ds-react'
+import {Box, Heading, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import Input from 'components/Forms/Input'
@@ -11,8 +12,6 @@ import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
 import { validateAvvis, ValidationAvvisProps } from './validation'
-import commonstyles from "assets/css/common.module.css"
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -77,10 +76,10 @@ const Avvis: React.FC<MainFormProps> = ({
             onChange={setBegrunnelseType}
           >
             <VStack gap="space-4" width="75%">
-              <Radio className={commonstyles.radioPanel} value='personen_finnes_ikke_i_våre_registre'>{t('el:option-avvis-01')}</Radio>
-              <Radio className={commonstyles.radioPanel} value='ikke_kompetent_institusjon_i_saken_og_ikke_i_stand_til_å_videresende'>{t('el:option-avvis-02')}</Radio>
-              <Radio className={commonstyles.radioPanel} value='etterspurt_obligatorisk_informasjon_finnes_ikke'>{t('el:option-avvis-03')}</Radio>
-              <Radio className={commonstyles.radioPanel} value='annet'>{t('el:option-avvis-99')}</Radio>
+              <RadioPanel value='personen_finnes_ikke_i_våre_registre'>{t('el:option-avvis-01')}</RadioPanel>
+              <RadioPanel value='ikke_kompetent_institusjon_i_saken_og_ikke_i_stand_til_å_videresende'>{t('el:option-avvis-02')}</RadioPanel>
+              <RadioPanel value='etterspurt_obligatorisk_informasjon_finnes_ikke'>{t('el:option-avvis-03')}</RadioPanel>
+              <RadioPanel value='annet'>{t('el:option-avvis-99')}</RadioPanel>
             </VStack>
           </RadioGroup>
         {(replySed as X011Sed).begrunnelseType === 'annet' && (

--- a/src/applications/SvarSed/BeløpNavnOgValuta/BeløpNavnOgValuta.tsx
+++ b/src/applications/SvarSed/BeløpNavnOgValuta/BeløpNavnOgValuta.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { Currency } from '@navikt/land-verktoy'
 import CountrySelect from '@navikt/landvelger'
 import { resetValidation, setValidation } from 'actions/validation'
@@ -307,9 +308,9 @@ const BeløpNavnOgValuta: React.FC<MainFormProps> = ({
                     onChange={(e: string) => setYtelseNavn(e as YtelseNavn, index)}
                   >
                     <VStack gap="space-4">
-                      <Radio className={commonStyles.radioPanel} value='Barnetrygd'>{t('el:option-familieytelser-barnetrygd')}</Radio>
-                      <Radio className={commonStyles.radioPanel} value='Kontantstøtte'>{t('el:option-familieytelser-kontantstøtte')}</Radio>
-                      {personID === 'familie' && <Radio className={commonStyles.radioPanel} value='Utvidet barnetrygd'>{t('el:option-familieytelser-utvidet-barnetrygd')}</Radio>}
+                      <RadioPanel value='Barnetrygd'>{t('el:option-familieytelser-barnetrygd')}</RadioPanel>
+                      <RadioPanel value='Kontantstøtte'>{t('el:option-familieytelser-kontantstøtte')}</RadioPanel>
+                      {personID === 'familie' && <RadioPanel value='Utvidet barnetrygd'>{t('el:option-familieytelser-utvidet-barnetrygd')}</RadioPanel>}
                     </VStack>
                   </RadioGroup>
                   <Box>
@@ -387,8 +388,8 @@ const BeløpNavnOgValuta: React.FC<MainFormProps> = ({
                   onChange={(e: string) => setUtbetalingshyppighet(e as Utbetalingshyppighet, index)}
                 >
                   <HStack gap="space-16">
-                    <Radio className={commonStyles.radioPanel} value='Månedlig'>{t('label:månedlig')}</Radio>
-                    <Radio className={commonStyles.radioPanel} value='Årlig'>{t('label:årlig')}</Radio>
+                    <RadioPanel value='Månedlig'>{t('label:månedlig')}</RadioPanel>
+                    <RadioPanel value='Årlig'>{t('label:årlig')}</RadioPanel>
                   </HStack>
                 </RadioGroup>
               </HGrid>

--- a/src/applications/SvarSed/BeløpNavnOgValuta/BeløpNavnOgValuta.tsx
+++ b/src/applications/SvarSed/BeløpNavnOgValuta/BeløpNavnOgValuta.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { Currency } from '@navikt/land-verktoy'
 import CountrySelect from '@navikt/landvelger'
 import { resetValidation, setValidation } from 'actions/validation'

--- a/src/applications/SvarSed/EndredeForhold/EndredeForhold.tsx
+++ b/src/applications/SvarSed/EndredeForhold/EndredeForhold.tsx
@@ -1,4 +1,5 @@
-import { Box, Heading, HStack, Radio, RadioGroup, VStack } from '@navikt/ds-react'
+import {Box, Heading, HStack, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateEndredeForhold, ValidationEndredeForholdProps } from 'applications/SvarSed/EndredeForhold/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -11,8 +12,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -70,12 +69,12 @@ const EndredeForhold: React.FC<MainFormProps> = ({
           onChange={(e: string | number | boolean) => setYtterligereInfoType(e as YtterligereInfoType)}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='melding_om_mer_informasjon'>
+            <RadioPanel value='melding_om_mer_informasjon'>
               {t('el:option-ytterligere-1')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel} value='anmodning_om_mer_informasjon'>
+            </RadioPanel>
+            <RadioPanel value='anmodning_om_mer_informasjon'>
               {t('el:option-ytterligere-2')}
-            </Radio>
+            </RadioPanel>
           </HStack>
         </RadioGroup>
         <TextArea

--- a/src/applications/SvarSed/EndredeForhold/EndredeForhold.tsx
+++ b/src/applications/SvarSed/EndredeForhold/EndredeForhold.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, HStack, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateEndredeForhold, ValidationEndredeForholdProps } from 'applications/SvarSed/EndredeForhold/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/applications/SvarSed/FamilieRelasjonF003/FamilieRelasjonF003.tsx
+++ b/src/applications/SvarSed/FamilieRelasjonF003/FamilieRelasjonF003.tsx
@@ -6,7 +6,7 @@ import {useAppDispatch, useAppSelector} from "../../../store";
 import {FamilieRelasjon, JaNei, Periode, ForelderType} from "../../../declarations/sed";
 import _ from "lodash";
 import {Box, Heading, HGrid, RadioGroup, VStack} from "@navikt/ds-react";
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import PeriodeInput from "../../../components/Forms/PeriodeInput";
 import Select from "../../../components/Forms/Select";
 import {Option, Options} from "../../../declarations/app";

--- a/src/applications/SvarSed/FamilieRelasjonF003/FamilieRelasjonF003.tsx
+++ b/src/applications/SvarSed/FamilieRelasjonF003/FamilieRelasjonF003.tsx
@@ -5,7 +5,8 @@ import {useTranslation} from "react-i18next";
 import {useAppDispatch, useAppSelector} from "../../../store";
 import {FamilieRelasjon, JaNei, Periode, ForelderType} from "../../../declarations/sed";
 import _ from "lodash";
-import {Box, Heading, HGrid, Radio, RadioGroup, VStack} from "@navikt/ds-react";
+import {Box, Heading, HGrid, RadioGroup, VStack} from "@navikt/ds-react";
+import RadioPanel from 'components/RadioPanel'
 import PeriodeInput from "../../../components/Forms/PeriodeInput";
 import Select from "../../../components/Forms/Select";
 import {Option, Options} from "../../../declarations/app";
@@ -149,8 +150,8 @@ const FamilieRelasjonF003: React.FC<MainFormProps> = ({
           onChange={(e: string) => setBorSammen(e as JaNei)}
         >
           <HGrid columns={2} gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-            <Radio className={commonStyles.radioPanel} value='nei'>{t('label:nei')}</Radio>
+            <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+            <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
           </HGrid>
         </RadioGroup>
       </VStack>

--- a/src/applications/SvarSed/Familierelasjon/Familierelasjon.tsx
+++ b/src/applications/SvarSed/Familierelasjon/Familierelasjon.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'

--- a/src/applications/SvarSed/Familierelasjon/Familierelasjon.tsx
+++ b/src/applications/SvarSed/Familierelasjon/Familierelasjon.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -334,8 +335,8 @@ const Familierelasjon: React.FC<MainFormProps> = ({
                 onChange={(e: string) => setBorSammen(e as JaNei, index)}
               >
                 <HStack gap="space-16">
-                  <Radio value='ja' className={commonStyles.radioPanel}>{t('label:ja')}</Radio>
-                  <Radio value='nei' className={commonStyles.radioPanel}>{t('label:nei')}</Radio>
+                  <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+                  <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
                 </HStack>
               </RadioGroup>
             </VStack>

--- a/src/applications/SvarSed/Klargjør/Klargjør.tsx
+++ b/src/applications/SvarSed/Klargjør/Klargjør.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import Input from 'components/Forms/Input'

--- a/src/applications/SvarSed/Klargjør/Klargjør.tsx
+++ b/src/applications/SvarSed/Klargjør/Klargjør.tsx
@@ -1,4 +1,5 @@
-import {Box, Heading, Radio, RadioGroup, VStack} from '@navikt/ds-react'
+import {Box, Heading, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import Input from 'components/Forms/Input'
@@ -11,8 +12,6 @@ import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
 import { validateKlargjør, ValidationKlargjørProps } from './validation'
-import commonStyles from "assets/css/common.module.css"
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -109,11 +108,11 @@ const Klargjør: React.FC<MainFormProps> = ({
           name={namespace + '-grunn'}
           onChange={setGrunn}
         >
-          <Radio className={commonStyles.radioPanel} value='informasjon_påkrevd_for_vår_nasjonale_undersøkelse'>{t('el:option-klargjør-01')}</Radio>
-          <Radio className={commonStyles.radioPanel} value='informasjon_påkrevd_for_beregning_av_ytelse'>{t('el:option-klargjør-02')}</Radio>
-          <Radio className={commonStyles.radioPanel} value='motstridende_informasjon_mottatt'>{t('el:option-klargjør-03')}</Radio>
-          <Radio className={commonStyles.radioPanel} value='det_må_vedlegges_støttedokumentasjon_belegg'>{t('el:option-klargjør-04')}</Radio>
-          <Radio className={commonStyles.radioPanel} value='annet'>{t('el:option-klargjør-99')}</Radio>
+          <RadioPanel value='informasjon_påkrevd_for_vår_nasjonale_undersøkelse'>{t('el:option-klargjør-01')}</RadioPanel>
+          <RadioPanel value='informasjon_påkrevd_for_beregning_av_ytelse'>{t('el:option-klargjør-02')}</RadioPanel>
+          <RadioPanel value='motstridende_informasjon_mottatt'>{t('el:option-klargjør-03')}</RadioPanel>
+          <RadioPanel value='det_må_vedlegges_støttedokumentasjon_belegg'>{t('el:option-klargjør-04')}</RadioPanel>
+          <RadioPanel value='annet'>{t('el:option-klargjør-99')}</RadioPanel>
         </RadioGroup>
         {klargjoerInfoItem?.begrunnelseType === 'annet' && (
           <Input

--- a/src/applications/SvarSed/MottakAvSoknad/MottakAvSoknad.tsx
+++ b/src/applications/SvarSed/MottakAvSoknad/MottakAvSoknad.tsx
@@ -11,7 +11,8 @@ import useUnmount from "../../../hooks/useUnmount";
 import _ from "lodash";
 import performValidation from "../../../utils/performValidation";
 import { validateKrav, ValidationKravProps } from "./validation";
-import {Box, HGrid, HStack, Radio, RadioGroup} from "@navikt/ds-react";
+import {Box, HGrid, HStack, RadioGroup} from "@navikt/ds-react";
+import RadioPanel from 'components/RadioPanel'
 import commonStyles from "assets/css/common.module.css";
 
 interface MottakAvSoknadSelector {
@@ -78,8 +79,8 @@ const MottakAvSoknad: React.FC<MainFormProps> = ({
           value={krav?.kravType}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='nytt_krav'>{t('label:kravType-nytt_krav')}</Radio>
-            <Radio className={commonStyles.radioPanel} value='endrede_omstendigheter'>{t('label:kravType-endrede_omstendigheter')}</Radio>
+            <RadioPanel value='nytt_krav'>{t('label:kravType-nytt_krav')}</RadioPanel>
+            <RadioPanel value='endrede_omstendigheter'>{t('label:kravType-endrede_omstendigheter')}</RadioPanel>
           </HStack>
         </RadioGroup>
       </HGrid>

--- a/src/applications/SvarSed/MottakAvSoknad/MottakAvSoknad.tsx
+++ b/src/applications/SvarSed/MottakAvSoknad/MottakAvSoknad.tsx
@@ -12,7 +12,7 @@ import _ from "lodash";
 import performValidation from "../../../utils/performValidation";
 import { validateKrav, ValidationKravProps } from "./validation";
 import {Box, HGrid, HStack, RadioGroup} from "@navikt/ds-react";
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import commonStyles from "assets/css/common.module.css";
 
 interface MottakAvSoknadSelector {

--- a/src/applications/SvarSed/PersonLight/PersonLight.tsx
+++ b/src/applications/SvarSed/PersonLight/PersonLight.tsx
@@ -1,4 +1,5 @@
-import {Alert, Box, Heading, HGrid, Radio, RadioGroup, VStack} from '@navikt/ds-react'
+import {Alert, Box, Heading, HGrid, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import DateField from 'components/DateField/DateField'
@@ -15,8 +16,6 @@ import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
 import { validatePersonLight, ValidationPersonLightProps } from './validation'
 import {isXSed} from "../../../utils/sed";
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -196,15 +195,15 @@ const PersonLightFC: React.FC<MainFormProps> = ({
           onChange={setKjoenn}
         >
           <HGrid columns={3} gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='M'>
+            <RadioPanel value='M'>
               {t(personID?.startsWith('barn') ? 'label:gutt' : 'label:mann')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel} value='K'>
+            </RadioPanel>
+            <RadioPanel value='K'>
               {t(personID?.startsWith('barn') ? 'label:jente' : 'label:kvinne')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel}value='U'>
+            </RadioPanel>
+            <RadioPanel value='U'>
               {t('label:ukjent')}
-            </Radio>
+            </RadioPanel>
           </HGrid>
         </RadioGroup>
       </VStack>

--- a/src/applications/SvarSed/PersonLight/PersonLight.tsx
+++ b/src/applications/SvarSed/PersonLight/PersonLight.tsx
@@ -1,5 +1,5 @@
 import {Alert, Box, Heading, HGrid, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import DateField from 'components/DateField/DateField'

--- a/src/applications/SvarSed/PersonOpplysninger/PersonOpplysninger.tsx
+++ b/src/applications/SvarSed/PersonOpplysninger/PersonOpplysninger.tsx
@@ -1,4 +1,5 @@
-import {Alert, Box, Heading, HGrid, HStack, Radio, RadioGroup, Spacer, TextField, VStack} from '@navikt/ds-react'
+import {Alert, Box, Heading, HGrid, HStack, RadioGroup, Spacer, TextField, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import {
@@ -18,9 +19,6 @@ import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
 import DateField from 'components/DateField/DateField'
-import commonStyles from 'assets/css/common.module.css'
-
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -258,15 +256,15 @@ const PersonOpplysninger: React.FC<MainFormProps> = ({
             onChange={setKjoenn}
           >
             <HStack  gap="space-16" align="center">
-              <Radio className={commonStyles.radioPanel} value='M'>
+              <RadioPanel value='M'>
                 {t(personID?.startsWith('barn') ? 'label:gutt' : 'label:mann')}
-              </Radio>
-              <Radio className={commonStyles.radioPanel} value='K'>
+              </RadioPanel>
+              <RadioPanel value='K'>
                 {t(personID?.startsWith('barn') ? 'label:jente' : 'label:kvinne')}
-              </Radio>
-              <Radio className={commonStyles.radioPanel} value='U'>
+              </RadioPanel>
+              <RadioPanel value='U'>
                 {t('label:ukjent')}
-              </Radio>
+              </RadioPanel>
             </HStack>
           </RadioGroup>
           <Heading size='small'>

--- a/src/applications/SvarSed/PersonOpplysninger/PersonOpplysninger.tsx
+++ b/src/applications/SvarSed/PersonOpplysninger/PersonOpplysninger.tsx
@@ -1,5 +1,5 @@
 import {Alert, Box, Heading, HGrid, HStack, RadioGroup, Spacer, TextField, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import {

--- a/src/applications/SvarSed/Påminnelse/Påminnelse.tsx
+++ b/src/applications/SvarSed/Påminnelse/Påminnelse.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Heading, HStack, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -205,15 +206,15 @@ const Påminnelse: React.FC<MainFormProps> = ({
                   onChange={(gjelder: string) => setPurringGjelder(gjelder, index)}
                 >
                   <HStack gap="space-16">
-                    <Radio className={commonStyles.radioPanel} value='dokument'>
+                    <RadioPanel value='dokument'>
                       {t('label:dokument')}
-                    </Radio>
-                    <Radio className={commonStyles.radioPanel} value='informasjon'>
+                    </RadioPanel>
+                    <RadioPanel value='informasjon'>
                       {t('label:informasjon')}
-                    </Radio>
-                    <Radio className={commonStyles.radioPanel} value='sed'>
+                    </RadioPanel>
+                    <RadioPanel value='sed'>
                       {t('label:sed')}
-                    </Radio>
+                    </RadioPanel>
                   </HStack>
                 </RadioGroup>
                 <Spacer/>

--- a/src/applications/SvarSed/Påminnelse/Påminnelse.tsx
+++ b/src/applications/SvarSed/Påminnelse/Påminnelse.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'

--- a/src/applications/SvarSed/Relasjon/Relasjon.tsx
+++ b/src/applications/SvarSed/Relasjon/Relasjon.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Checkbox, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetAdresse } from 'actions/adresse'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/applications/SvarSed/Relasjon/Relasjon.tsx
+++ b/src/applications/SvarSed/Relasjon/Relasjon.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { BodyLong, Box, Button, Checkbox, Heading, HGrid, HStack, Label, Radio, RadioGroup, Spacer, VStack } from '@navikt/ds-react'
+import {BodyLong, Box, Button, Checkbox, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetAdresse } from 'actions/adresse'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -299,10 +300,10 @@ const Relasjon: React.FC<MainFormProps> = ({
                 onChange={(e: string) => setRelasjon(e as BarnRelasjon, index)}
               >
                 <HStack gap="space-16">
-                  <Radio className={commonStyles.radioPanel} value='søker'>{t('label:søker')}</Radio>
-                  <Radio className={commonStyles.radioPanel} value='ektefelle_partner'>{t('label:ektefelle_partner')}</Radio>
-                  <Radio className={commonStyles.radioPanel} value='avdød'>{t('label:avdød')}</Radio>
-                  <Radio className={commonStyles.radioPanel} value='annen_person'>{t('label:annen_person')}</Radio>
+                  <RadioPanel value='søker'>{t('label:søker')}</RadioPanel>
+                  <RadioPanel value='ektefelle_partner'>{t('label:ektefelle_partner')}</RadioPanel>
+                  <RadioPanel value='avdød'>{t('label:avdød')}</RadioPanel>
+                  <RadioPanel value='annen_person'>{t('label:annen_person')}</RadioPanel>
                 </HStack>
               </RadioGroup>
               <HGrid columns="1fr 2fr" gap="space-16" align="start">
@@ -341,8 +342,8 @@ const Relasjon: React.FC<MainFormProps> = ({
                   onChange={(e: string) => setErDeltForeldreansvar(e as JaNei, index)}
                 >
                   <HStack gap="space-16">
-                    <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-                    <Radio className={commonStyles.radioPanel} value='nei'>{t('label:nei')}</Radio>
+                    <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+                    <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
                   </HStack>
                 </RadioGroup>
               </HGrid>

--- a/src/applications/SvarSed/RettTilYtelserFSED/RettTilYtelserFSED.tsx
+++ b/src/applications/SvarSed/RettTilYtelserFSED/RettTilYtelserFSED.tsx
@@ -1,5 +1,5 @@
 import {BodyLong, Box, Button, Heading, HGrid, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import {resetValidation, setValidation} from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'

--- a/src/applications/SvarSed/RettTilYtelserFSED/RettTilYtelserFSED.tsx
+++ b/src/applications/SvarSed/RettTilYtelserFSED/RettTilYtelserFSED.tsx
@@ -1,4 +1,5 @@
-import {BodyLong, Box, Button, Heading, HGrid, HStack, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HGrid, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import {resetValidation, setValidation} from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
@@ -264,8 +265,8 @@ const RettTilYtelserFSED: React.FC<MainFormProps> = ({
             onChange={(e: string) => setRettTilFamilieYtelser(e as JaNei)}
           >
             <HStack gap="space-16">
-              <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='nei'>{t('label:nei')}</Radio>
+              <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+              <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
             </HStack>
           </RadioGroup>
           <Spacer />
@@ -324,9 +325,9 @@ const RettTilYtelserFSED: React.FC<MainFormProps> = ({
                 onChange={setIkkeRettTilFamilieYtelser}
               >
                 <HStack gap="space-16">
-                  {isF026Sed(replySed) && <Radio className={commonStyles.radioPanel} value='krav_ikke_framsatt'>{t('label:krav-ikke-framsatt')}</Radio>}
-                  <Radio className={commonStyles.radioPanel} value='for_høy_inntekt'>{t('label:for-hoy-inntekt')}</Radio>
-                  <Radio className={commonStyles.radioPanel} value='annen_grunn'>{t('label:annet')}</Radio>
+                  {isF026Sed(replySed) && <RadioPanel value='krav_ikke_framsatt'>{t('label:krav-ikke-framsatt')}</RadioPanel>}
+                  <RadioPanel value='for_høy_inntekt'>{t('label:for-hoy-inntekt')}</RadioPanel>
+                  <RadioPanel value='annen_grunn'>{t('label:annet')}</RadioPanel>
                 </HStack>
               </RadioGroup>
               <Spacer/>

--- a/src/applications/SvarSed/SisteAnsettelseInfo/SisteAnsettelseInfo.tsx
+++ b/src/applications/SvarSed/SisteAnsettelseInfo/SisteAnsettelseInfo.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { BodyLong, Box, Button, Heading, HGrid, HStack, Label, Radio, RadioGroup, Spacer, VStack } from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import CountryData, { Currency } from '@navikt/land-verktoy'
 import CountrySelect from '@navikt/landvelger'
 import { resetValidation, setValidation } from 'actions/validation'
@@ -293,15 +294,15 @@ const SisteAnsettelseInfoFC: React.FC<MainFormProps> = ({
                   onChange={(e: string) => setUtbetalingType(e, index)}
                 >
                   <VStack gap="space-8">
-                    <Radio className={commonStyles.radioPanel} value='inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet'>
+                    <RadioPanel value='inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet'>
                       {t('el:option-typebeløp-inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet')}
-                    </Radio>
-                    <Radio className={commonStyles.radioPanel} value='vederlag_for_ferie_som_ikke_er_tatt_ut_årlig_ferie'>
+                    </RadioPanel>
+                    <RadioPanel value='vederlag_for_ferie_som_ikke_er_tatt_ut_årlig_ferie'>
                       {t('el:option-typebeløp-vederlag_for_ferie_som_ikke_er_tatt_ut_årlig_ferie')}
-                    </Radio>
-                    <Radio className={commonStyles.radioPanel} value='annet_vederlag_eller_tilsvarende_utbetalinger'>
+                    </RadioPanel>
+                    <RadioPanel value='annet_vederlag_eller_tilsvarende_utbetalinger'>
                       {t('el:option-typebeløp-annet_vederlag_eller_tilsvarende_utbetalinger')}
-                    </Radio>
+                    </RadioPanel>
                   </VStack>
                 </RadioGroup>
                 )

--- a/src/applications/SvarSed/SisteAnsettelseInfo/SisteAnsettelseInfo.tsx
+++ b/src/applications/SvarSed/SisteAnsettelseInfo/SisteAnsettelseInfo.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import CountryData, { Currency } from '@navikt/land-verktoy'
 import CountrySelect from '@navikt/landvelger'
 import { resetValidation, setValidation } from 'actions/validation'

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ErBarnetAdoptert.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ErBarnetAdoptert.tsx
@@ -1,5 +1,5 @@
 import {VStack, Box, Heading, RadioGroup, HStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import _ from 'lodash'

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ErBarnetAdoptert.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ErBarnetAdoptert.tsx
@@ -1,4 +1,5 @@
-import {VStack, Box, Heading, Radio, RadioGroup, HStack} from '@navikt/ds-react'
+import {VStack, Box, Heading, RadioGroup, HStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import _ from 'lodash'
@@ -16,8 +17,6 @@ import {
   validateErAdoptert, ValidationAnnenInformasjonBarnetProps
 } from "./validation";
 import {setValidation} from "../../../actions/validation";
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -81,12 +80,12 @@ const ErBarnetAdoptert: React.FC<MainFormProps> = ({
               onChange={(e:string) => setAnnenInformasjonBarnetProperty("erAdoptert",  e as JaNei)}
             >
               <HStack gap="space-16">
-                <Radio className={commonStyles.radioPanel} value='ja'>
+                <RadioPanel value='ja'>
                   Ja
-                </Radio>
-                <Radio className={commonStyles.radioPanel} value='nei'>
+                </RadioPanel>
+                <RadioPanel value='nei'>
                   Nei
-                </Radio>
+                </RadioPanel>
               </HStack>
             </RadioGroup>
           </Box>

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ForsoergesAvDetOffentlige.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ForsoergesAvDetOffentlige.tsx
@@ -1,5 +1,5 @@
 import {VStack, Box, Heading, RadioGroup, HStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import _ from 'lodash'

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ForsoergesAvDetOffentlige.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/ForsoergesAvDetOffentlige.tsx
@@ -1,4 +1,5 @@
-import {VStack, Box, Heading, Radio, RadioGroup, HStack} from '@navikt/ds-react'
+import {VStack, Box, Heading, RadioGroup, HStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import _ from 'lodash'
@@ -16,8 +17,6 @@ import {
   validateForsoergesAvDetOffentlige, ValidationAnnenInformasjonBarnetProps,
 } from "./validation";
 import {setValidation} from "../../../actions/validation";
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -81,12 +80,12 @@ const ForsoergesAvDetOffentlige: React.FC<MainFormProps> = ({
               onChange={(e:string) => setAnnenInformasjonBarnetProperty("forsoergesAvDetOffentlige",  e as JaNei)}
             >
               <HStack gap="space-16">
-                <Radio className={commonStyles.radioPanel} value='ja'>
+                <RadioPanel value='ja'>
                   Ja
-                </Radio>
-                <Radio className={commonStyles.radioPanel} value='nei'>
+                </RadioPanel>
+                <RadioPanel value='nei'>
                   Nei
-                </Radio>
+                </RadioPanel>
               </HStack>
             </RadioGroup>
           </Box>

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/InformasjonOmBarnehage.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/InformasjonOmBarnehage.tsx
@@ -1,5 +1,5 @@
 import {VStack, Box, Heading, HGrid, TextField, Label, Select, RadioGroup, HStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import _ from 'lodash'

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/InformasjonOmBarnehage.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/InformasjonOmBarnehage.tsx
@@ -1,4 +1,5 @@
-import {VStack, Box, Heading, HGrid, TextField, Label, Select, Radio, RadioGroup, HStack} from '@navikt/ds-react'
+import {VStack, Box, Heading, HGrid, TextField, Label, Select, RadioGroup, HStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import _ from 'lodash'
@@ -17,8 +18,6 @@ import {
   ValidationAnnenInformasjonBarnetProps
 } from "./validation";
 import {setValidation} from "../../../actions/validation";
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -84,12 +83,12 @@ const InformasjonOmBarnehage: React.FC<MainFormProps> = ({
               onChange={(e:string) => setAnnenInformasjonBarnetProperty('barnehage.gaarIBarnehage', e as JaNei)}
             >
               <HStack gap="space-16">
-                <Radio className={commonStyles.radioPanel} value='ja'>
+                <RadioPanel value='ja'>
                   Ja
-                </Radio>
-                <Radio className={commonStyles.radioPanel} value='nei'>
+                </RadioPanel>
+                <RadioPanel value='nei'>
                   Nei
-                </Radio>
+                </RadioPanel>
               </HStack>
             </RadioGroup>
           </Box>
@@ -104,12 +103,12 @@ const InformasjonOmBarnehage: React.FC<MainFormProps> = ({
                   onChange={(e:string) => setAnnenInformasjonBarnetProperty('barnehage.mottarOffentligStoette', e as JaNei)}
                 >
                   <HStack gap="space-16">
-                    <Radio className={commonStyles.radioPanel} value='ja'>
+                    <RadioPanel value='ja'>
                       Ja
-                    </Radio>
-                    <Radio className={commonStyles.radioPanel} value='nei'>
+                    </RadioPanel>
+                    <RadioPanel value='nei'>
                       Nei
-                    </Radio>
+                    </RadioPanel>
                   </HStack>
                 </RadioGroup>
               </Box>

--- a/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonAnnenPersonOgAvdoede/RelasjonAnnenPersonOgAvdoede.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonAnnenPersonOgAvdoede/RelasjonAnnenPersonOgAvdoede.tsx
@@ -11,7 +11,8 @@ import {
   SvarYtelseTilForeldreloese_V43
 } from "../../../../declarations/sed";
 import _ from "lodash";
-import {BodyLong, Box, Button, Heading, VStack, HGrid, Select, Label, HStack, Radio, RadioGroup, Spacer} from "@navikt/ds-react";
+import {BodyLong, Box, Button, Heading, VStack, HGrid, Select, Label, HStack, RadioGroup, Spacer} from "@navikt/ds-react";
+import RadioPanel from 'components/RadioPanel'
 import TextArea from "../../../../components/Forms/TextArea";
 import {PlusCircleIcon} from "@navikt/aksel-icons";
 import {getIdx} from "../../../../utils/namespace";
@@ -286,12 +287,12 @@ const RelasjonAnnenPersonOgAvdoede: React.FC<MainFormProps> = ({
                     onChange={(e:string) => setRelasjonProperty("varKravstillerISammeHushold",  e as JaNei,"var-kravstiller-i-samme-hushold", index)}
                   >
                     <HStack gap="space-16">
-                      <Radio className={commonStyles.radioPanel} value='ja'>
+                      <RadioPanel value='ja'>
                         Ja
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='nei'>
+                      </RadioPanel>
+                      <RadioPanel value='nei'>
                         Nei
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
 

--- a/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonAnnenPersonOgAvdoede/RelasjonAnnenPersonOgAvdoede.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonAnnenPersonOgAvdoede/RelasjonAnnenPersonOgAvdoede.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../declarations/sed";
 import _ from "lodash";
 import {BodyLong, Box, Button, Heading, VStack, HGrid, Select, Label, HStack, RadioGroup, Spacer} from "@navikt/ds-react";
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import TextArea from "../../../../components/Forms/TextArea";
 import {PlusCircleIcon} from "@navikt/aksel-icons";
 import {getIdx} from "../../../../utils/namespace";

--- a/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonForeldreloeseBarnetOgAvdoede/RelasjonForeldreloeseBarnetOgAvdoede.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonForeldreloeseBarnetOgAvdoede/RelasjonForeldreloeseBarnetOgAvdoede.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../../../declarations/sed";
 import _ from "lodash";
 import {BodyLong, Box, Button, Heading, VStack, HGrid, Select, Label, HStack, RadioGroup, Spacer} from "@navikt/ds-react";
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import TextArea from "../../../../components/Forms/TextArea";
 import {PlusCircleIcon} from "@navikt/aksel-icons";
 import {getIdx} from "../../../../utils/namespace";

--- a/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonForeldreloeseBarnetOgAvdoede/RelasjonForeldreloeseBarnetOgAvdoede.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonForeldreloeseBarnetOgAvdoede/RelasjonForeldreloeseBarnetOgAvdoede.tsx
@@ -11,7 +11,8 @@ import {
   SvarYtelseTilForeldreloese_V43
 } from "../../../../declarations/sed";
 import _ from "lodash";
-import {BodyLong, Box, Button, Heading, VStack, HGrid, Select, Label, HStack, Radio, RadioGroup, Spacer} from "@navikt/ds-react";
+import {BodyLong, Box, Button, Heading, VStack, HGrid, Select, Label, HStack, RadioGroup, Spacer} from "@navikt/ds-react";
+import RadioPanel from 'components/RadioPanel'
 import TextArea from "../../../../components/Forms/TextArea";
 import {PlusCircleIcon} from "@navikt/aksel-icons";
 import {getIdx} from "../../../../utils/namespace";
@@ -216,20 +217,20 @@ const RelasjonForeldreloeseBarnetOgAvdoede: React.FC<MainFormProps> = ({
                   >
                     <VStack gap="space-8">
                       <HStack gap="space-16">
-                        <Radio className={commonStyles.radioPanel} value='soeker'>
+                        <RadioPanel value='soeker'>
                           {t('el:option-relasjonbarn-relasjontilperson-soeker')}
-                        </Radio>
-                        <Radio className={commonStyles.radioPanel} value='ektefelle_partner'>
+                        </RadioPanel>
+                        <RadioPanel value='ektefelle_partner'>
                           {t('el:option-relasjonbarn-relasjontilperson-ektefelle_partner')}
-                        </Radio>
+                        </RadioPanel>
                       </HStack>
                       <HStack gap="space-16">
-                        <Radio className={commonStyles.radioPanel} value='avdoed'>
+                        <RadioPanel value='avdoed'>
                           {t('el:option-relasjonbarn-relasjontilperson-avdoed')}
-                        </Radio>
-                        <Radio className={commonStyles.radioPanel} value='annen_person'>
+                        </RadioPanel>
+                        <RadioPanel value='annen_person'>
                           {t('el:option-relasjonbarn-relasjontilperson-annen_person')}
-                        </Radio>
+                        </RadioPanel>
                       </HStack>
                     </VStack>
                   </RadioGroup>
@@ -272,12 +273,12 @@ const RelasjonForeldreloeseBarnetOgAvdoede: React.FC<MainFormProps> = ({
                     onChange={(e:string) => setRelasjonProperty("fellesOmsorg",  e as JaNei,"felles-omsorg", index)}
                   >
                     <HStack gap="space-16">
-                      <Radio className={commonStyles.radioPanel} value='ja'>
+                      <RadioPanel value='ja'>
                         Ja
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='nei'>
+                      </RadioPanel>
+                      <RadioPanel value='nei'>
                         Nei
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   <RadioGroup
@@ -289,12 +290,12 @@ const RelasjonForeldreloeseBarnetOgAvdoede: React.FC<MainFormProps> = ({
                     onChange={(e:string) => setRelasjonProperty("borISammeHusstandSomKravstiller",  e as JaNei,"bor-i-samme-hustand-som-kravstiller", index)}
                   >
                     <HStack gap="space-16">
-                      <Radio className={commonStyles.radioPanel} value='ja'>
+                      <RadioPanel value='ja'>
                         Ja
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='nei'>
+                      </RadioPanel>
+                      <RadioPanel value='nei'>
                         Nei
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   <RadioGroup
@@ -306,12 +307,12 @@ const RelasjonForeldreloeseBarnetOgAvdoede: React.FC<MainFormProps> = ({
                     onChange={(e:string) => setRelasjonProperty("borISammeHusstandSomEktefelle",  e as JaNei,"bor-i-samme-hustand-som-ektefelle", index)}
                   >
                     <HStack gap="space-16">
-                      <Radio className={commonStyles.radioPanel} value='ja'>
+                      <RadioPanel value='ja'>
                         Ja
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='nei'>
+                      </RadioPanel>
+                      <RadioPanel value='nei'>
                         Nei
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   <RadioGroup
@@ -323,12 +324,12 @@ const RelasjonForeldreloeseBarnetOgAvdoede: React.FC<MainFormProps> = ({
                     onChange={(e:string) => setRelasjonProperty("borISammeHusstandSomAnnenPerson",  e as JaNei,"bor-i-samme-hustand-som-annen-person", index)}
                   >
                     <HStack gap="space-16">
-                      <Radio className={commonStyles.radioPanel} value='ja'>
+                      <RadioPanel value='ja'>
                         Ja
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='nei'>
+                      </RadioPanel>
+                      <RadioPanel value='nei'>
                         Nei
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   <RadioGroup
@@ -340,12 +341,12 @@ const RelasjonForeldreloeseBarnetOgAvdoede: React.FC<MainFormProps> = ({
                     onChange={(e:string) => setRelasjonProperty("borPaaInstitusjon",  e as JaNei,"bor-paa-institusjon", index)}
                   >
                     <HStack gap="space-16">
-                      <Radio className={commonStyles.radioPanel} value='ja'>
+                      <RadioPanel value='ja'>
                         Ja
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='nei'>
+                      </RadioPanel>
+                      <RadioPanel value='nei'>
                         Nei
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   {addremovepanel}

--- a/src/applications/SvarSed/SvarPaaAnmodningOmInformasjon/SvarPaaAnmodningOmInformasjon.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmInformasjon/SvarPaaAnmodningOmInformasjon.tsx
@@ -11,11 +11,10 @@ import useUnmount from "../../../hooks/useUnmount";
 import _ from "lodash";
 import performValidation from "../../../utils/performValidation";
 import { validateKrav, ValidationKravProps } from "./validation";
-import {Box, Checkbox, HGrid, HStack, Radio, RadioGroup, VStack} from "@navikt/ds-react";
+import {Box, Checkbox, HGrid, HStack, RadioGroup, VStack} from "@navikt/ds-react";
+import RadioPanel from 'components/RadioPanel'
 import {setDeselectedMenu} from "../../../actions/svarsed";
 import ErrorLabel from "../../../components/Forms/ErrorLabel";
-import commonStyles from 'assets/css/common.module.css'
-
 interface KravSelector {
   validation: Validation
 }
@@ -105,12 +104,12 @@ const SvarPaaAnmodningOmInformasjon: React.FC<MainFormProps> = ({
                 value={erKravEllerSvarPaaKrav}
               >
                 <HStack gap="space-16">
-                  <Radio className={commonStyles.radioPanel} value='krav'>
+                  <RadioPanel value='krav'>
                     {t('label:krav-eller-svar-paa-krav-nytt_krav')}
-                  </Radio>
-                  <Radio className={commonStyles.radioPanel} value='svar_paa_krav'>
+                  </RadioPanel>
+                  <RadioPanel value='svar_paa_krav'>
                     {t('label:krav-eller-svar-paa-krav-svar-paa-krav')}
-                  </Radio>
+                  </RadioPanel>
                 </HStack>
               </RadioGroup>
             </HGrid>

--- a/src/applications/SvarSed/SvarPaaAnmodningOmInformasjon/SvarPaaAnmodningOmInformasjon.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmInformasjon/SvarPaaAnmodningOmInformasjon.tsx
@@ -12,7 +12,7 @@ import _ from "lodash";
 import performValidation from "../../../utils/performValidation";
 import { validateKrav, ValidationKravProps } from "./validation";
 import {Box, Checkbox, HGrid, HStack, RadioGroup, VStack} from "@navikt/ds-react";
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import {setDeselectedMenu} from "../../../actions/svarsed";
 import ErrorLabel from "../../../components/Forms/ErrorLabel";
 interface KravSelector {

--- a/src/applications/SvarSed/SvarPåForespørsel/SvarPåForespørsel.tsx
+++ b/src/applications/SvarSed/SvarPåForespørsel/SvarPåForespørsel.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, HGrid, Label, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import {

--- a/src/applications/SvarSed/SvarPåForespørsel/SvarPåForespørsel.tsx
+++ b/src/applications/SvarSed/SvarPåForespørsel/SvarPåForespørsel.tsx
@@ -1,11 +1,11 @@
-import { Box, Heading, HGrid, Label, Radio, RadioGroup, VStack } from '@navikt/ds-react'
+import {Box, Heading, HGrid, Label, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import {
   validateSvarPåForespørsel,
   ValidationSvarPåForespørselProps
 } from 'applications/SvarSed/SvarPåForespørsel/validation'
-import commonStyles from 'assets/css/common.module.css'
 import TextArea from 'components/Forms/TextArea'
 import { State } from 'declarations/reducers'
 import { H002Sed, H002Svar, HSvarType } from 'declarations/sed'
@@ -165,12 +165,12 @@ const SvarPåForespørsel: React.FC<MainFormProps> = ({
             }}
           >
             <HGrid columns={2} gap="space-16" align="start">
-              <Radio className={commonStyles.radioPanel} description={t('message:help-jeg-kan-sende')} value='positivt'>
+              <RadioPanel description={t('message:help-jeg-kan-sende')} value='positivt'>
                 {t('el:option-svar-1')}
-              </Radio>
-              <Radio className={commonStyles.radioPanel} description={t('message:help-jeg-kan-ikke-sende')} value='negativt'>
+              </RadioPanel>
+              <RadioPanel description={t('message:help-jeg-kan-ikke-sende')} value='negativt'>
                 {t('el:option-svar-2')}
-              </Radio>
+              </RadioPanel>
             </HGrid>
           </RadioGroup>
         </div>

--- a/src/applications/SvarSed/SvarPåminnelse/SvarPåminnelse.tsx
+++ b/src/applications/SvarSed/SvarPåminnelse/SvarPåminnelse.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'

--- a/src/applications/SvarSed/SvarPåminnelse/SvarPåminnelse.tsx
+++ b/src/applications/SvarSed/SvarPåminnelse/SvarPåminnelse.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Heading, HGrid, HStack, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Heading, HGrid, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -397,15 +398,15 @@ const SvarPåminnelse: React.FC<MainFormProps> = ({
                     onChange={(type: string) => setBesvarelseKommerType(type, index)}
                   >
                     <HStack gap="space-16" width="100%">
-                      <Radio className={commonStyles.radioPanel} value='dokument'>
+                      <RadioPanel value='dokument'>
                         {t('label:dokument')}
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='informasjon'>
+                      </RadioPanel>
+                      <RadioPanel value='informasjon'>
                         {t('label:informasjon')}
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='sed'>
+                      </RadioPanel>
+                      <RadioPanel value='sed'>
                         {t('label:sed')}
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   <Spacer/>
@@ -534,15 +535,15 @@ const SvarPåminnelse: React.FC<MainFormProps> = ({
                     onChange={(type: string) => setBesvarelseUmuligType(type, index)}
                   >
                     <HStack gap="space-16" width="100%">
-                      <Radio className={commonStyles.radioPanel} value='dokument'>
+                      <RadioPanel value='dokument'>
                         {t('label:dokument')}
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='informasjon'>
+                      </RadioPanel>
+                      <RadioPanel value='informasjon'>
                         {t('label:informasjon')}
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='sed'>
+                      </RadioPanel>
+                      <RadioPanel value='sed'>
                         {t('label:sed')}
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                   <Spacer/>
@@ -572,7 +573,7 @@ const SvarPåminnelse: React.FC<MainFormProps> = ({
                   onChange={(begrunnelseType: string) => setBegrunnelseType(begrunnelseType, index)}
                 >
                   {begrunnelsetypeOptions.map((option) => {
-                    return <Radio className={commonStyles.radioPanel} value={option.value}>{option.label}</Radio>
+                    return <RadioPanel value={option.value}>{option.label}</RadioPanel>
                   })}
                 </RadioGroup>
                 {_BesvarelseUmulig?.begrunnelseType === 'annet' && (

--- a/src/applications/SvarSed/Trygdeordning/DekkedePerioder.tsx
+++ b/src/applications/SvarSed/Trygdeordning/DekkedePerioder.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Checkbox, HGrid, HStack, Label, RadioGroup, Spacer, Tag, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'

--- a/src/applications/SvarSed/Trygdeordning/DekkedePerioder.tsx
+++ b/src/applications/SvarSed/Trygdeordning/DekkedePerioder.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Checkbox, HGrid, HStack, Label, Radio, RadioGroup, Spacer, Tag, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Checkbox, HGrid, HStack, Label, RadioGroup, Spacer, Tag, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -251,12 +252,12 @@ const DekkedePerioder: React.FC<DekkedePerioderProps> = ({
                     onChange={(newType: string) => setType(newType, index)}
                   >
                     <HStack gap="space-16" width="100%">
-                      <Radio className={commonStyles.radioPanel} value='dekkedePerioder'>
+                      <RadioPanel value='dekkedePerioder'>
                         {t('label:dekkede')}
-                      </Radio>
-                      <Radio className={commonStyles.radioPanel} value='udekkedePerioder'>
+                      </RadioPanel>
+                      <RadioPanel value='udekkedePerioder'>
                         {t('label:udekkede')}
-                      </Radio>
+                      </RadioPanel>
                     </HStack>
                   </RadioGroup>
                 </HGrid>

--- a/src/applications/SvarSed/Ugyldiggjøre/Ugyldiggjøre.tsx
+++ b/src/applications/SvarSed/Ugyldiggjøre/Ugyldiggjøre.tsx
@@ -1,4 +1,5 @@
-import { Box, Heading, HGrid, Radio, RadioGroup, VStack } from '@navikt/ds-react'
+import {Box, Heading, HGrid, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import Input from 'components/Forms/Input'
@@ -11,8 +12,6 @@ import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
 import { validateUgyldiggjøre, ValidationUgyldiggjøreProps } from './validation'
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -74,13 +73,13 @@ const Ugyldiggjøre: React.FC<MainFormProps> = ({
             onChange={setBegrunnelseType}
           >
             <VStack gap="space-4">
-              <Radio className={commonStyles.radioPanel} value='personen_er_død'>{t('el:option-ugyldiggjøre-01')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='saken_ble_feilaktig_sendt_til_dere'>{t('el:option-ugyldiggjøre-02')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='feilaktig_informasjon_levert'>{t('el:option-ugyldiggjøre-03')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='saken_ble_revurdert_og_sed_en_er_ikke_lenger_vurdert_som_ugyldig'>{t('el:option-ugyldiggjøre-04')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='det_nasjonale_vedtaket_ble_bestridt_av_kunden_Mer_informasjon_vil_følge_etter_endelig_beslutning_om_bestridelsen'>{t('el:option-ugyldiggjøre-05')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='det_nasjonale_vedtaket_ble_bestridt_av_kunden_Det_vil_ikke_sendes_flere_sed_er'>{t('el:option-ugyldiggjøre-06')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='annet'>{t('el:option-ugyldiggjøre-99')}</Radio>
+              <RadioPanel value='personen_er_død'>{t('el:option-ugyldiggjøre-01')}</RadioPanel>
+              <RadioPanel value='saken_ble_feilaktig_sendt_til_dere'>{t('el:option-ugyldiggjøre-02')}</RadioPanel>
+              <RadioPanel value='feilaktig_informasjon_levert'>{t('el:option-ugyldiggjøre-03')}</RadioPanel>
+              <RadioPanel value='saken_ble_revurdert_og_sed_en_er_ikke_lenger_vurdert_som_ugyldig'>{t('el:option-ugyldiggjøre-04')}</RadioPanel>
+              <RadioPanel value='det_nasjonale_vedtaket_ble_bestridt_av_kunden_Mer_informasjon_vil_følge_etter_endelig_beslutning_om_bestridelsen'>{t('el:option-ugyldiggjøre-05')}</RadioPanel>
+              <RadioPanel value='det_nasjonale_vedtaket_ble_bestridt_av_kunden_Det_vil_ikke_sendes_flere_sed_er'>{t('el:option-ugyldiggjøre-06')}</RadioPanel>
+              <RadioPanel value='annet'>{t('el:option-ugyldiggjøre-99')}</RadioPanel>
             </VStack>
           </RadioGroup>
           <div />

--- a/src/applications/SvarSed/Ugyldiggjøre/Ugyldiggjøre.tsx
+++ b/src/applications/SvarSed/Ugyldiggjøre/Ugyldiggjøre.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, HGrid, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import Input from 'components/Forms/Input'

--- a/src/applications/SvarSed/Utdanning/Utdanning.tsx
+++ b/src/applications/SvarSed/Utdanning/Utdanning.tsx
@@ -1,4 +1,5 @@
-import {HStack, Label, Radio, RadioGroup, VStack} from '@navikt/ds-react'
+import {HStack, Label, RadioGroup, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import React from "react";
 import {MainFormProps, MainFormSelector} from "../MainForm";
 import TextArea from "../../../components/Forms/TextArea";
@@ -45,11 +46,11 @@ const Utdanning: React.FC<MainFormProps> = ({
         error={validation[namespace + '-type']?.feilmelding}
       >
         <HStack gap="space-8">
-          <Radio className={commonStyles.radioPanel} value='skole'>Skole</Radio>
-          <Radio className={commonStyles.radioPanel} value='høyskole'>Høyskole</Radio>
-          <Radio className={commonStyles.radioPanel} value='universitet'>Universitet</Radio>
-          <Radio className={commonStyles.radioPanel} value='yrkesrettet_opplæring'>Yrkesrettet opplæring</Radio>
-          <Radio className={commonStyles.radioPanel} value='barnehage_daghjem'>Barnehage/Daghjem</Radio>
+          <RadioPanel value='skole'>Skole</RadioPanel>
+          <RadioPanel value='høyskole'>Høyskole</RadioPanel>
+          <RadioPanel value='universitet'>Universitet</RadioPanel>
+          <RadioPanel value='yrkesrettet_opplæring'>Yrkesrettet opplæring</RadioPanel>
+          <RadioPanel value='barnehage_daghjem'>Barnehage/Daghjem</RadioPanel>
         </HStack>
       </RadioGroup>
       <RadioGroup
@@ -60,8 +61,8 @@ const Utdanning: React.FC<MainFormProps> = ({
         error={validation[namespace + '-typedeltakelse']?.feilmelding}
       >
         <HStack gap="space-8">
-          <Radio className={commonStyles.radioPanel} value='deltid'>Deltid</Radio>
-          <Radio className={commonStyles.radioPanel} value='heltid'>Heltid</Radio>
+          <RadioPanel value='deltid'>Deltid</RadioPanel>
+          <RadioPanel value='heltid'>Heltid</RadioPanel>
         </HStack>
       </RadioGroup>
       <Label>Faktisk deltakelse</Label>
@@ -73,9 +74,9 @@ const Utdanning: React.FC<MainFormProps> = ({
         id={namespace + '-timer-pr'}
       >
         <HStack gap="space-8">
-          <Radio className={commonStyles.radioPanel} value='dag'>Dag</Radio>
-          <Radio className={commonStyles.radioPanel} value='uke'>Uke</Radio>
-          <Radio className={commonStyles.radioPanel} value='maaned'>Måned</Radio>
+          <RadioPanel value='dag'>Dag</RadioPanel>
+          <RadioPanel value='uke'>Uke</RadioPanel>
+          <RadioPanel value='maaned'>Måned</RadioPanel>
         </HStack>
       </RadioGroup>
       <Input

--- a/src/applications/SvarSed/Utdanning/Utdanning.tsx
+++ b/src/applications/SvarSed/Utdanning/Utdanning.tsx
@@ -1,5 +1,5 @@
 import {HStack, Label, RadioGroup, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import React from "react";
 import {MainFormProps, MainFormSelector} from "../MainForm";
 import TextArea from "../../../components/Forms/TextArea";

--- a/src/applications/SvarSed/Vedtak/Vedtak.tsx
+++ b/src/applications/SvarSed/Vedtak/Vedtak.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Checkbox, Heading, HGrid, HStack, Label, Radio, RadioGroup, Spacer, Tag, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Checkbox, Heading, HGrid, HStack, Label, RadioGroup, Spacer, Tag, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetAdresse } from 'actions/adresse'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -566,8 +567,8 @@ const VedtakFC: React.FC<MainFormProps> = ({
                         onChange={(e: string) => setKompetansePeriodeSkalYtelseUtbetales(e as JaNei, index)}
                       >
                         <HStack gap="space-16" align="center">
-                          <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-                          <Radio className={commonStyles.radioPanel} value='nei'>{t('label:nei')}</Radio>
+                          <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+                          <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
                         </HStack>
                       </RadioGroup>
                     }
@@ -641,8 +642,8 @@ const VedtakFC: React.FC<MainFormProps> = ({
             onChange={(e: string) => setGjelderAlleBarn(e as JaNei)}
           >
             <HStack  gap="space-16" align="center">
-              <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-              <Radio className={commonStyles.radioPanel} value='nei'>{t('label:nei')}</Radio>
+              <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+              <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
               <Spacer/>
             </HStack>
           </RadioGroup>

--- a/src/applications/SvarSed/Vedtak/Vedtak.tsx
+++ b/src/applications/SvarSed/Vedtak/Vedtak.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Checkbox, Heading, HGrid, HStack, Label, RadioGroup, Spacer, Tag, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetAdresse } from 'actions/adresse'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/applications/SvarSed/VedtakForF003/VedtakForF003.tsx
+++ b/src/applications/SvarSed/VedtakForF003/VedtakForF003.tsx
@@ -1,5 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import {BodyLong, Box, Button, Checkbox, Heading, HStack, Label, Radio, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import {BodyLong, Box, Button, Checkbox, Heading, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetAdresse } from 'actions/adresse'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -329,8 +330,8 @@ const VedtakForF003: React.FC<MainFormProps> = ({
               onChange={(e: string) => setGjelderAlleBarn(e as JaNei)}
             >
               <HStack gap="space-16">
-                <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-                <Radio className={commonStyles.radioPanel} value='nei'>{t('label:nei')}</Radio>
+                <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+                <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
               </HStack>
             </RadioGroup>
           </HStack>
@@ -429,8 +430,8 @@ const VedtakForF003: React.FC<MainFormProps> = ({
                 onChange={setUtvidetBarnetrygd}
               >
                 <HStack gap="space-16">
-                  <Radio className={commonStyles.radioPanel} value='ja'>{t('label:ja')}</Radio>
-                  <Radio className={commonStyles.radioPanel}value='nei'>{t('label:nei')}</Radio>
+                  <RadioPanel value='ja'>{t('label:ja')}</RadioPanel>
+                  <RadioPanel value='nei'>{t('label:nei')}</RadioPanel>
                 </HStack>
               </RadioGroup>
             </HStack>

--- a/src/applications/SvarSed/VedtakForF003/VedtakForF003.tsx
+++ b/src/applications/SvarSed/VedtakForF003/VedtakForF003.tsx
@@ -1,6 +1,6 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Checkbox, Heading, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetAdresse } from 'actions/adresse'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/applications/SvarSed/YtterligereInfoOmKrav/YtterligereInfoOmKrav.tsx
+++ b/src/applications/SvarSed/YtterligereInfoOmKrav/YtterligereInfoOmKrav.tsx
@@ -1,4 +1,5 @@
-import { Box, Heading, HStack, Radio, RadioGroup, Spacer, VStack } from '@navikt/ds-react'
+import {Box, Heading, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
+import RadioPanel from 'components/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateYtterligereInfoOmKrav, ValidationYtterligereInfoOmKravProps } from 'applications/SvarSed/YtterligereInfoOmKrav/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
@@ -14,8 +15,6 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
-import commonStyles from 'assets/css/common.module.css'
-
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
@@ -190,12 +189,12 @@ const YtterligereInfoOmKrav: React.FC<MainFormProps> = ({
           onChange={setErBrukerSoekeren}
         >
           <HStack gap="space-16">
-            <Radio className={commonStyles.radioPanel} value='ja'>
+            <RadioPanel value='ja'>
               {t('label:ja')}
-            </Radio>
-            <Radio className={commonStyles.radioPanel} value='nei'>
+            </RadioPanel>
+            <RadioPanel value='nei'>
               {t('label:nei')}
-            </Radio>
+            </RadioPanel>
             <Spacer />
             <Spacer />
           </HStack>

--- a/src/applications/SvarSed/YtterligereInfoOmKrav/YtterligereInfoOmKrav.tsx
+++ b/src/applications/SvarSed/YtterligereInfoOmKrav/YtterligereInfoOmKrav.tsx
@@ -1,5 +1,5 @@
 import {Box, Heading, HStack, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
-import RadioPanel from 'components/RadioPanel'
+import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { resetValidation, setValidation } from 'actions/validation'
 import { validateYtterligereInfoOmKrav, ValidationYtterligereInfoOmKravProps } from 'applications/SvarSed/YtterligereInfoOmKrav/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'

--- a/src/assets/css/common.module.css
+++ b/src/assets/css/common.module.css
@@ -1,26 +1,3 @@
-.radioPanel{
-  flex: 1;
-  background-color: var(--ax-bg-input);
-  width: 100%;
-  border-radius: 4px;
-  padding: 0.8rem 0.5rem;
-  align-items: center;
-  &:focus-within::after {
-    inset: 0;
-    border-radius: 4px;
-  }
-}
-
-.radioPanel:has(input[type=radio]:checked){
-  background-color: var(--ax-bg-accent-moderate-hover);
-  border-radius: 4px;
-}
-
-.radioPanel:hover {
-  background-color: var(--ax-bg-accent-moderate-hover);
-  border-radius: 4px;
-}
-
 .horizontalLineSeparator {
   height: 1px;
   margin-top: 0;

--- a/src/components/RadioPanel/RadioPanel.module.css
+++ b/src/components/RadioPanel/RadioPanel.module.css
@@ -3,12 +3,18 @@
   background-color: var(--ax-bg-input);
   width: 100%;
   border-radius: 4px;
-  padding: 0.8rem 0.5rem;
+  padding: 0;
   align-items: center;
   &:focus-within::after {
     inset: 0;
     border-radius: 4px;
   }
+}
+
+.radioPanel :global(.aksel-radio) {
+  width: 100%;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 .radioPanel:has(input[type=radio]:checked) {

--- a/src/components/RadioPanel/RadioPanel.module.css
+++ b/src/components/RadioPanel/RadioPanel.module.css
@@ -1,0 +1,22 @@
+.radioPanel {
+  flex: 1;
+  background-color: var(--ax-bg-input);
+  width: 100%;
+  border-radius: 4px;
+  padding: 0.8rem 0.5rem;
+  align-items: center;
+  &:focus-within::after {
+    inset: 0;
+    border-radius: 4px;
+  }
+}
+
+.radioPanel:has(input[type=radio]:checked) {
+  background-color: var(--ax-bg-accent-moderate-hover);
+  border-radius: 4px;
+}
+
+.radioPanel:hover {
+  background-color: var(--ax-bg-accent-moderate-hover);
+  border-radius: 4px;
+}

--- a/src/components/RadioPanel/RadioPanel.module.css
+++ b/src/components/RadioPanel/RadioPanel.module.css
@@ -5,16 +5,27 @@
   border-radius: 4px;
   padding: 0;
   align-items: center;
-  &:focus-within::after {
-    inset: 0;
-    border-radius: 4px;
-  }
+  position: relative;
+}
+
+.radioPanel:focus-within::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 4px;
+  outline: 3px solid var(--ax-border-focus);
+  outline-offset: 3px;
+  pointer-events: none;
 }
 
 .radioPanel :global(.aksel-radio) {
   width: 100%;
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+}
+
+.radioPanel :global(.aksel-radio):focus-within::after {
+  outline: none;
 }
 
 .radioPanel:has(input[type=radio]:checked) {

--- a/src/components/RadioPanel/RadioPanel.tsx
+++ b/src/components/RadioPanel/RadioPanel.tsx
@@ -1,0 +1,24 @@
+import { Radio, RadioProps } from '@navikt/ds-react'
+import React from 'react'
+import styles from './RadioPanel.module.css'
+
+export interface RadioPanelProps extends RadioProps {
+  wrapperClassName?: string
+}
+
+const RadioPanel: React.FC<RadioPanelProps> = ({
+  wrapperClassName,
+  children,
+  ...radioProps
+}) => {
+  const className = wrapperClassName
+    ? `${styles.radioPanel} ${wrapperClassName}`
+    : styles.radioPanel
+  return (
+    <div className={className}>
+      <Radio {...radioProps}>{children}</Radio>
+    </div>
+  )
+}
+
+export default RadioPanel

--- a/src/components/RadioPanel/index.ts
+++ b/src/components/RadioPanel/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RadioPanel'
+export type { RadioPanelProps } from './RadioPanel'

--- a/src/components/RadioPanel/index.ts
+++ b/src/components/RadioPanel/index.ts
@@ -1,2 +1,0 @@
-export { default } from './RadioPanel'
-export type { RadioPanelProps } from './RadioPanel'


### PR DESCRIPTION
Resolves [TEN-1658](https://jira.adeo.no/browse/TEN-1658)

## Problem
Aksel ds-react 8.9.1 changed Radio's internal layout (display: grid). Applying `className={commonStyles.radioPanel}` directly to `<Radio>` now also styles the underlying input element, making the radio button stretched and square.

## Changes
- New `RadioPanel` wrapper component (`src/components/RadioPanel/`) that wraps a plain `<Radio>` in a `<div>` carrying the panel CSS, so styles target the wrapper instead of the Radio.
- Migrated all 33 usages (~120 occurrences) of `<Radio className={commonStyles.radioPanel} ...>` to `<RadioPanel ...>`.
- Moved `.radioPanel` rules from `src/assets/css/common.module.css` to `src/components/RadioPanel/RadioPanel.module.css`.

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅
- Aksel `RadioGroup` uses React Context, so wrapping `Radio` in a `<div>` does not break grouping behavior.