### PR TITLE
fix: migrate currency dropdowns to use correct currencyCodeListName (TEN-1661)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "13.7.0",
+  "version": "13.8.0-TEN-1661-CURRENCY-DROPDOWN-CODELIST",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "13.7.0",
+      "version": "13.8.0-TEN-1661-CURRENCY-DROPDOWN-CODELIST",
       "dependencies": {
         "@navikt/aksel-icons": "8.9.0",
         "@navikt/ds-css": "8.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.7.0",
+  "version": "13.8.0-TEN-1661-CURRENCY-DROPDOWN-CODELIST",
   "private": true,
   "type": "module",
   "scripts": {
@@ -206,6 +206,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@13.7.0"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/package.json
+++ b/package.json
@@ -206,5 +206,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@13.8.0-TEN-1661-CURRENCY-DROPDOWN-CODELIST"
 }

--- a/src/applications/SvarSed/AktivitetOgTrygdeperioder/Ansatt/Ansatt.tsx
+++ b/src/applications/SvarSed/AktivitetOgTrygdeperioder/Ansatt/Ansatt.tsx
@@ -11,7 +11,7 @@ import PeriodeText from 'components/Forms/PeriodeText'
 import ForsikringPeriodeBox from 'components/ForsikringPeriodeBox/ForsikringPeriodeBox'
 import { ErrorElement } from 'declarations/app.d'
 import { State } from 'declarations/reducers'
-import {ForsikringPeriode, Periode, PeriodeMedForsikring} from 'declarations/sed'
+import {ForsikringPeriode, Periode, PeriodeMedForsikring, ReplySed} from 'declarations/sed'
 import { ArbeidsperiodeFraAA, ArbeidsperioderFraAA, Validation } from 'declarations/types'
 import useLocalValidation from 'hooks/useLocalValidation'
 import _ from 'lodash'
@@ -55,6 +55,7 @@ const Ansatt: React.FC<AnsattProps> = ({
   const dispatch = useAppDispatch()
   const namespace = `${parentNamespace}`
   const target = `${personID}.${parentTarget}`
+  const currencyCodeListName = (replySed as ReplySed)?.sedType?.startsWith('U') ? 'verdensValuta' : 'euEftaValuta'
   const perioder: Array<Periode> | undefined = _.get(replySed, target)
   const fnr = getFnr(replySed, personID)
   const getId = (item: PlanItem<Periode | ForsikringPeriode> | null): string => (item
@@ -267,6 +268,7 @@ const Ansatt: React.FC<AnsattProps> = ({
         validation={validation}
         resetValidation={doResetValidation}
         setValidation={doSetValidation}
+        currencyCodeListName={currencyCodeListName}
       />
     )
   }

--- a/src/applications/SvarSed/ArbeidsperioderOversikt/ArbeidsperioderOversikt.tsx
+++ b/src/applications/SvarSed/ArbeidsperioderOversikt/ArbeidsperioderOversikt.tsx
@@ -64,6 +64,7 @@ const ArbeidsperioderOversikt: React.FC<MainFormProps> = ({
 
   const namespace = `${parentNamespace}-${personID}-arbeidsperioder`
   const forsikringNamespace = `${parentNamespace}-${personID}-forsikring`
+  const currencyCodeListName = (replySed as ReplySed)?.sedType?.startsWith('U') ? 'verdensValuta' : 'euEftaValuta'
   const target = 'perioderAnsattMedForsikring'
   const perioder: Array<PeriodeMedForsikring> | Array<PDPeriode> | undefined = _.get(replySed, target)
   const anmodningsperiode: Periode | undefined = _.get(replySed, "anmodningsperiode")
@@ -297,6 +298,7 @@ const ArbeidsperioderOversikt: React.FC<MainFormProps> = ({
           setValidation={doSetValidation}
           setCopiedPeriod={_setCopiedPeriod}
           index={index}
+          currencyCodeListName={currencyCodeListName}
        />
       </>
     )

--- a/src/applications/SvarSed/BeløpNavnOgValuta/BeløpNavnOgValuta.tsx
+++ b/src/applications/SvarSed/BeløpNavnOgValuta/BeløpNavnOgValuta.tsx
@@ -2,7 +2,7 @@ import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
 import RadioPanel from 'components/RadioPanel/RadioPanel'
 import { Currency } from '@navikt/land-verktoy'
-import CountrySelect from '@navikt/landvelger'
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -342,17 +342,16 @@ const BeløpNavnOgValuta: React.FC<MainFormProps> = ({
                   value={_ytelse?.beloep}
                 />
 
-                <CountrySelect
+                <CurrencyDropdown
                   closeMenuOnSelect
                   ariaLabel={t('label:valuta')}
-                  data-testid={_namespace + '-valuta'}
+                  dataTestId={_namespace + '-valuta'}
                   error={_v[_namespace + '-valuta']?.feilmelding}
                   id={_namespace + '-valuta'}
                   label={t('label:valuta') + ' *'}
                   locale='nb'
-                  menuPortalTarget={document.body}
                   onOptionSelected={(e: any) => setValuta(e, index)}
-                  type='currency'
+                  currencyCodeListName='euEftaValuta'
                   values={_ytelse?.valuta}
                 />
               </HGrid>

--- a/src/applications/SvarSed/Forsikring/Forsikring.tsx
+++ b/src/applications/SvarSed/Forsikring/Forsikring.tsx
@@ -58,6 +58,7 @@ const Forsikring: React.FC<MainFormProps> = ({
 
   const namespace = `${parentNamespace}-${personID}-forsikring`
   const arbeidsPerioderNamespace = `${parentNamespace}-${personID}-arbeidsperioder`
+  const currencyCodeListName = (replySed as ReplySed)?.sedType?.startsWith('U') ? 'verdensValuta' : 'euEftaValuta'
   const getId = (p: ForsikringPeriode | null | undefined): string => p ? p.__type + '[' + p.__index + ']' : 'new-forsikring'
 
   const [_allPeriods, _setAllPeriods] = useState<Array<ForsikringPeriode>>([])
@@ -332,6 +333,7 @@ const Forsikring: React.FC<MainFormProps> = ({
                     setCopiedPeriod={_setCopiedPeriod}
                     index={index}
                     type={_type}
+                    currencyCodeListName={currencyCodeListName}
                   />
                 </Box>
               )}
@@ -360,6 +362,7 @@ const Forsikring: React.FC<MainFormProps> = ({
                   setCopiedPeriod={_setCopiedPeriod}
                   index={index}
                   type={_type}
+                  currencyCodeListName={currencyCodeListName}
                 />
               )}
             </VStack>

--- a/src/applications/SvarSed/InntektForm/InntektForm.tsx
+++ b/src/applications/SvarSed/InntektForm/InntektForm.tsx
@@ -17,7 +17,7 @@ import ForsikringPeriodeBox from 'components/ForsikringPeriodeBox/ForsikringPeri
 import InntektFC from 'components/Inntekt/Inntekt'
 import WaitingPanel from 'components/WaitingPanel/WaitingPanel'
 import { State } from 'declarations/reducers'
-import {Loennsopplysning, Periode, PeriodeMedForsikring, AnsettelsesType, USed} from 'declarations/sed'
+import {Loennsopplysning, Periode, PeriodeMedForsikring, AnsettelsesType, ReplySed, USed} from 'declarations/sed'
 import { Inntekt } from 'declarations/sed.d'
 import { ArbeidsperioderFraAA, IInntekter, Validation } from 'declarations/types'
 import useLocalValidation from 'hooks/useLocalValidation'
@@ -72,6 +72,7 @@ const InntektForm: React.FC<MainFormProps> = ({
 
   const CDM_VERSJON: number = parseFloat((replySed as USed)?.sak?.cdmVersjon!)
   const namespace = `${parentNamespace}-${personID}-inntekt`
+  const currencyCodeListName = (replySed as ReplySed)?.sedType?.startsWith('U') ? 'verdensValuta' : 'euEftaValuta'
   const target = 'loennsopplysninger'
   const loennsopplysninger: Array<Loennsopplysning> | undefined = _.get(replySed, target)
   const fnr: string | undefined = getFnr(replySed, personID)
@@ -512,6 +513,7 @@ const InntektForm: React.FC<MainFormProps> = ({
                   forsikringPeriode={period}
                   showArbeidsgiver
                   namespace={namespace}
+                  currencyCodeListName={currencyCodeListName}
                 />
               )
             })}

--- a/src/applications/SvarSed/Inntekter/Inntekter.tsx
+++ b/src/applications/SvarSed/Inntekter/Inntekter.tsx
@@ -1,7 +1,7 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyLong, Box, Button, HGrid, HStack, Label, Spacer, VStack } from '@navikt/ds-react'
 import { Currency } from '@navikt/land-verktoy'
-import CountrySelect from '@navikt/landvelger'
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import { resetValidation, setValidation } from 'actions/validation'
 import classNames from 'classnames'
 import AddRemovePanel from 'components/AddRemovePanel/AddRemovePanel'
@@ -237,17 +237,16 @@ const Inntekter: React.FC<any> = ({
                     required
                     value={_inntekt?.beloep ? _inntekt?.beloep.replace('.', ',') : undefined}
                   />
-                  <CountrySelect
+                  <CurrencyDropdown
                     closeMenuOnSelect
                     ariaLabel={t('label:valuta')}
-                    data-testid={namespace + '-valuta'}
+                    dataTestId={namespace + '-valuta'}
                     error={_v[_namespace + '-valuta']?.feilmelding}
                     id={_namespace + '-valuta'}
                     label={t('label:valuta') + ' *'}
                     locale='nb'
-                    menuPortalTarget={document.body}
                     onOptionSelected={(valuta: Currency) => setValuta(valuta, index)}
-                    type='currency'
+                    currencyCodeListName='verdensValuta'
                     values={_inntekt?.valuta}
                   />
                 </HGrid>

--- a/src/applications/SvarSed/KravOmRefusjon/Refusjon.tsx
+++ b/src/applications/SvarSed/KravOmRefusjon/Refusjon.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import {ArrowRightLeftIcon, PlusCircleIcon} from "@navikt/aksel-icons";
 import Input from "../../../components/Forms/Input";
-import CountrySelect from "@navikt/landvelger";
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import {Currency} from "@navikt/land-verktoy";
 import {Validation} from "../../../declarations/types";
 import {getIdx} from "../../../utils/namespace";
@@ -192,16 +192,15 @@ const RefusjonFC: React.FC<MainFormProps> = ({
               onChanged={(value: string) => setRefusjonProp("totalbeloep", sanitizeAmount(value))}
               value={refusjon?.totalbeloep || ''}
             />
-            <CountrySelect
+            <CurrencyDropdown
               ariaLabel={t('label:valuta')}
               closeMenuOnSelect
               error={validation[namespace + '-valuta']?.feilmelding}
               id={namespace + '-valuta'}
               label={t('label:valuta')}
               locale='nb'
-              menuPortalTarget={document.body}
               onOptionSelected={(currency: Currency) => setRefusjonProp("valuta", currency.value)}
-              type='currency'
+              currencyCodeListName='euEftaValuta'
               values={refusjon?.valuta}
             />
           </HGrid>
@@ -275,17 +274,16 @@ const RefusjonFC: React.FC<MainFormProps> = ({
                 onChanged={(value: string) => setRefusjonsKravProp("beloep", sanitizeAmount(value), index)}
                 value={_refusjonskrav?.beloep}
               />
-              <CountrySelect
+              <CurrencyDropdown
                 ariaLabel={t('label:valuta')}
                 closeMenuOnSelect
-                data-testid={_namespace + '-valuta'}
+                dataTestId={_namespace + '-valuta'}
                 error={_v[_namespace + '-valuta']?.feilmelding}
                 id={_namespace + '-valuta'}
                 label={t('label:valuta')}
                 locale='nb'
-                menuPortalTarget={document.body}
                 onOptionSelected={(currency: Currency) => setRefusjonsKravProp("valuta", currency.value, index)}
-                type='currency'
+                currencyCodeListName='euEftaValuta'
                 required={true}
                 values={_refusjonskrav?.valuta}
               />

--- a/src/applications/SvarSed/Motregninger/Motregninger.tsx
+++ b/src/applications/SvarSed/Motregninger/Motregninger.tsx
@@ -15,7 +15,7 @@ import Input from "../../../components/Forms/Input";
 import {Validation} from "../../../declarations/types";
 import useLocalValidation from "../../../hooks/useLocalValidation";
 import {validateMotregning, validateMotregninger, ValidationMotregningerProps, ValidationMotregningProps} from "./validation";
-import CountrySelect from "@navikt/landvelger";
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import PeriodeInput from "../../../components/Forms/PeriodeInput";
 import TextArea from "../../../components/Forms/TextArea";
 import {Currency} from "@navikt/land-verktoy";
@@ -418,17 +418,16 @@ const MotregningerFC: React.FC<MainFormProps> = ({
                 onChanged={(value: string) => setMotregningProp("beloep", sanitizeAmount(value), index)}
                 value={_motregning?.beloep}
               />
-              <CountrySelect
+              <CurrencyDropdown
                 ariaLabel={t('label:valuta')}
                 closeMenuOnSelect
-                data-testid={_namespace + '-valuta'}
+                dataTestId={_namespace + '-valuta'}
                 error={_v[_namespace + '-valuta']?.feilmelding}
                 id={_namespace + '-valuta'}
                 label={t('label:valuta')}
                 locale='nb'
-                menuPortalTarget={document.body}
                 onOptionSelected={(currency: Currency) => setMotregningProp("valuta", currency.value, index)}
-                type='currency'
+                currencyCodeListName='euEftaValuta'
                 required={true}
                 values={_motregning?.valuta}
               />
@@ -553,16 +552,15 @@ const MotregningerFC: React.FC<MainFormProps> = ({
               onChanged={(value: string) => setOppsummeringProp("totalbeloep", sanitizeAmount(value), type)}
               value={(motregninger as any)?.[target]?.totalbeloep || ''}
             />
-            <CountrySelect
+            <CurrencyDropdown
               ariaLabel={t('label:valuta')}
               closeMenuOnSelect
               error={validation[namespace + '-' + target + '-valuta']?.feilmelding}
               id={namespace + '-' + target + '-valuta'}
               label={t('label:valuta')}
               locale='nb'
-              menuPortalTarget={document.body}
               onOptionSelected={(currency: Currency) => setOppsummeringProp("valuta", currency.value, type)}
-              type='currency'
+              currencyCodeListName='euEftaValuta'
               values={(motregninger as any)?.[target]?.valuta}
             />
           </HGrid>

--- a/src/applications/SvarSed/SisteAnsettelseInfo/SisteAnsettelseInfo.tsx
+++ b/src/applications/SvarSed/SisteAnsettelseInfo/SisteAnsettelseInfo.tsx
@@ -2,7 +2,7 @@ import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, Heading, HGrid, HStack, Label, RadioGroup, Spacer, VStack} from '@navikt/ds-react'
 import RadioPanel from 'components/RadioPanel/RadioPanel'
 import CountryData, { Currency } from '@navikt/land-verktoy'
-import CountrySelect from '@navikt/landvelger'
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import classNames from 'classnames'
@@ -335,17 +335,16 @@ const SisteAnsettelseInfoFC: React.FC<MainFormProps> = ({
                   required
                   value={_utbetaling?.beloep}
                 />
-                <CountrySelect
+                <CurrencyDropdown
                   closeMenuOnSelect
                   ariaLabel={t('label:valuta')}
-                  data-testid={_namespace + '-valuta'}
+                  dataTestId={_namespace + '-valuta'}
                   error={_v[_namespace + '-valuta']?.feilmelding}
                   id={_namespace + '-valuta'}
                   label={t('label:valuta') + ' *'}
                   locale='nb'
-                  menuPortalTarget={document.body}
                   onOptionSelected={(c: Currency) => setValuta(c, index)}
-                  type='currency'
+                  currencyCodeListName='verdensValuta'
                   values={_currencyData.findByValue(_utbetaling?.valuta)}
                 />
                 <Box>

--- a/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/InntektForeldreloeseBarnet.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/InntektForeldreloeseBarnet.tsx
@@ -9,7 +9,7 @@ import {State} from "../../../declarations/reducers";
 import {sanitizeAmount} from "../../../utils/amount";
 import {SvarYtelseTilForeldreloese_V42, SvarYtelseTilForeldreloese_V43} from "../../../declarations/sed";
 import Input from "../../../components/Forms/Input";
-import CountrySelect from "@navikt/landvelger";
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import {Currency} from "@navikt/land-verktoy";
 import useUnmount from "../../../hooks/useUnmount";
 import performValidation from "../../../utils/performValidation";
@@ -82,17 +82,16 @@ const InntektForeldreloeseBarnet: React.FC<MainFormProps> = ({
                 onChanged={(v) => setYtelseTilForeldreloeseProperty('inntekt.beloep', sanitizeAmount(v))}
                 value={(svarYtelseTilForeldreloese as SvarYtelseTilForeldreloese_V43)?.barnet?.inntekt?.beloep ?? ''}
               />
-              <CountrySelect
+              <CurrencyDropdown
                 closeMenuOnSelect
                 ariaLabel={t('label:valuta')}
-                data-testid={namespace + '-valuta'}
+                dataTestId={namespace + '-valuta'}
                 error={validation[namespace + '-valuta']?.feilmelding}
                 id={namespace + '-valuta'}
                 label={t('label:valuta')}
                 locale='nb'
-                menuPortalTarget={document.body}
                 onOptionSelected={(c: Currency) => setYtelseTilForeldreloeseProperty('inntekt.valuta', c.value)}
-                type='currency'
+                currencyCodeListName='euEftaValuta'
                 values={(svarYtelseTilForeldreloese as SvarYtelseTilForeldreloese_V43)?.barnet?.inntekt?.valuta}
               />
             </HGrid>

--- a/src/applications/SvarSed/SvarPaaAnmodningOmInntekt/SvarPaaAnmodningOmInntekt.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmInntekt/SvarPaaAnmodningOmInntekt.tsx
@@ -10,7 +10,7 @@ import {sanitizeAmount} from "../../../utils/amount";
 import {useTranslation} from "react-i18next";
 import Input from "../../../components/Forms/Input";
 import DateField from "../../../components/DateField/DateField";
-import CountrySelect from "@navikt/landvelger";
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import {Currency} from "@navikt/land-verktoy";
 import useUnmount from "../../../hooks/useUnmount";
 import performValidation from "../../../utils/performValidation";
@@ -116,16 +116,15 @@ const SvarPaaAnmodningOmInntekt: React.FC<MainFormProps> = ({
                 onChanged={(v) => setInntektProperty('aarlig.beloep', sanitizeAmount(v))}
                 value={svarInntekt?.aarlig?.beloep}
               />
-              <CountrySelect
+              <CurrencyDropdown
                 closeMenuOnSelect
                 ariaLabel={t('label:valuta')}
                 error={validation[namespace + '-aarlig-valuta']?.feilmelding}
                 id={namespace + '-aarlig-valuta'}
                 label={t('label:valuta')}
                 locale='nb'
-                menuPortalTarget={document.body}
                 onOptionSelected={(valuta: Currency) => setInntektProperty('aarlig.valuta', valuta.value)}
-                type='currency'
+                currencyCodeListName='euEftaValuta'
                 sort="noeuFirst"
                 values={svarInntekt?.aarlig?.valuta}
               />

--- a/src/components/CurrencyDropdown/CurrencyDropdown.tsx
+++ b/src/components/CurrencyDropdown/CurrencyDropdown.tsx
@@ -23,12 +23,14 @@ export interface CurrencyDropdownProps extends CountrySelectProps<any> {
    * 'euEftaValuta' = EU/EFTA-valutaer, 'verdensValuta' = alle valutaer akseptert av Rina. */
   currencyCodeListName?: keyof CurrencyCodeLists
   menuPortalTarget?: HTMLElement | null
+  includeHistoricCurrencies?: boolean
 }
 
 const CurrencyDropdown: React.FC<CurrencyDropdownProps> = ({
   currencyCodeListName = 'verdensValuta',
   dataTestId,
   menuPortalTarget = document.body,
+  includeHistoricCurrencies = true,
   ...rest
 }: CurrencyDropdownProps) => {
 
@@ -53,6 +55,7 @@ const CurrencyDropdown: React.FC<CurrencyDropdownProps> = ({
       menuPortalTarget={menuPortalTarget}
       data-testid={dataTestId}
       includeList={includeList}
+      includeHistoricCurrencies={includeHistoricCurrencies}
     />
   )
 }

--- a/src/components/CurrencyDropdown/CurrencyDropdown.tsx
+++ b/src/components/CurrencyDropdown/CurrencyDropdown.tsx
@@ -26,7 +26,7 @@ export interface CurrencyDropdownProps extends CountrySelectProps<any> {
 }
 
 const CurrencyDropdown: React.FC<CurrencyDropdownProps> = ({
-  currencyCodeListName = 'euEftaValuta',
+  currencyCodeListName = 'verdensValuta',
   dataTestId,
   menuPortalTarget = document.body,
   ...rest

--- a/src/components/ForsikringPeriodeBox/ForsikringPeriodeBox.tsx
+++ b/src/components/ForsikringPeriodeBox/ForsikringPeriodeBox.tsx
@@ -1,6 +1,6 @@
 import {Accordion, BodyLong, Box, Checkbox, Heading, HGrid, HStack, Label, Spacer, VStack} from '@navikt/ds-react'
 import { Currency } from '@navikt/land-verktoy'
-import CountrySelect from '@navikt/landvelger'
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import AdresseForm from 'applications/SvarSed/Adresser/AdresseForm'
 import IdentifikatorFC from 'applications/SvarSed/Identifikator/Identifikator'
 import classNames from 'classnames'
@@ -24,7 +24,7 @@ import {
   PeriodeMedForsikring,
   PeriodeUtenForsikring
 } from 'declarations/sed.d'
-import { Validation } from 'declarations/types'
+import { CurrencyCodeLists, Validation } from 'declarations/types'
 import useLocalValidation from 'hooks/useLocalValidation'
 import _ from 'lodash'
 import React, {useState} from 'react'
@@ -66,6 +66,7 @@ export interface ArbeidsgiverBoxProps<T> {
   setCopiedPeriod?: (p:any | null) => void
   index?: number | undefined
   type?: string | undefined
+  currencyCodeListName?: keyof CurrencyCodeLists
 }
 
 const ForsikringPeriodeBox = <T extends ForsikringPeriode>({
@@ -95,7 +96,8 @@ const ForsikringPeriodeBox = <T extends ForsikringPeriode>({
   setValidation,
   setCopiedPeriod,
   index,
-  type
+  type,
+  currencyCodeListName
 }: ArbeidsgiverBoxProps<T>): JSX.Element => {
   const { t } = useTranslation()
 
@@ -563,6 +565,7 @@ const ForsikringPeriodeBox = <T extends ForsikringPeriode>({
                   parentNamespace={namespace}
                   inntektOgTimer={(_forsikringPeriode as PeriodeUtenForsikring)?.inntektOgTimer}
                   onInntektOgTimeChanged={setInntektOgTimer}
+                  currencyCodeListName={currencyCodeListName}
                 />
                 <Input
                   error={_v[namespace + '-inntektOgTimerInfo']?.feilmelding}
@@ -598,17 +601,16 @@ const ForsikringPeriodeBox = <T extends ForsikringPeriode>({
                   required
                   value={(_forsikringPeriode as PeriodeFerieForsikring)?.beloep ? (_forsikringPeriode as PeriodeFerieForsikring)?.beloep?.replace('.', ',') : undefined}
                 />
-                <CountrySelect
+                <CurrencyDropdown
                   closeMenuOnSelect
                   ariaLabel={t('label:valuta')}
-                  data-testid={namespace + '-valuta'}
+                  dataTestId={namespace + '-valuta'}
                   error={_v[namespace + '-valuta']?.feilmelding}
                   id={namespace + '-valuta'}
                   label={t('label:valuta') + ' *'}
                   locale='nb'
-                  menuPortalTarget={document.body}
                   onOptionSelected={setValuta}
-                  type='currency'
+                  currencyCodeListName={currencyCodeListName}
                   values={(_forsikringPeriode as PeriodeFerieForsikring)?.valuta}
                 />
               </HGrid>

--- a/src/components/ForsikringPeriodeBox/InntektOgTimer/InntektOgTimer.tsx
+++ b/src/components/ForsikringPeriodeBox/InntektOgTimer/InntektOgTimer.tsx
@@ -1,7 +1,7 @@
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import {BodyLong, Box, Button, HGrid, HStack, Label, Spacer, VStack} from '@navikt/ds-react'
 import { Currency } from '@navikt/land-verktoy'
-import CountrySelect from '@navikt/landvelger'
+import CurrencyDropdown from 'components/CurrencyDropdown/CurrencyDropdown'
 import { resetValidation, setValidation } from 'actions/validation'
 import classNames from 'classnames'
 import AddRemovePanel from 'components/AddRemovePanel/AddRemovePanel'
@@ -12,7 +12,7 @@ import PeriodeText from 'components/Forms/PeriodeText'
 import { InntektOgTime, Periode } from 'declarations/sed'
 import { sanitizeAmount } from 'utils/amount'
 import commonStyles from 'assets/css/common.module.css'
-import { Validation } from 'declarations/types'
+import {CurrencyCodeLists, Validation} from 'declarations/types'
 import useLocalValidation from 'hooks/useLocalValidation'
 import _ from 'lodash'
 import React, { useState } from 'react'
@@ -29,6 +29,7 @@ export interface InntektOgTimerProps {
   parentNamespace: string
   personName?: string
   validation: Validation
+  currencyCodeListName?: keyof CurrencyCodeLists
 }
 
 const InntektOgTimerFC: React.FC<InntektOgTimerProps> = ({
@@ -36,7 +37,8 @@ const InntektOgTimerFC: React.FC<InntektOgTimerProps> = ({
   onInntektOgTimeChanged,
   parentNamespace,
   personName,
-  validation
+  validation,
+  currencyCodeListName
 }: InntektOgTimerProps): JSX.Element => {
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
@@ -247,17 +249,16 @@ const InntektOgTimerFC: React.FC<InntektOgTimerProps> = ({
                 required
                 value={_inntektOgTime?.bruttoinntekt ? _inntektOgTime?.bruttoinntekt.replace('.', ',') : undefined}
               />
-              <CountrySelect
+              <CurrencyDropdown
                 closeMenuOnSelect
                 ariaLabel={t('label:valuta')}
-                data-testid={_namespace + '-valuta'}
+                dataTestId={_namespace + '-valuta'}
                 error={_v[_namespace + '-valuta']?.feilmelding}
                 id={_namespace + '-valuta'}
                 label={t('label:valuta') + ' *'}
                 locale='nb'
-                menuPortalTarget={document.body}
                 onOptionSelected={(valuta: Currency) => setValuta(valuta, index)}
-                type='currency'
+                currencyCodeListName={currencyCodeListName}
                 values={_inntektOgTime?.valuta}
               />
               <Input


### PR DESCRIPTION
Resolves [TEN-1661](https://jira.adeo.no/browse/TEN-1661)

## Changes

Migrates all remaining `CountrySelect type='currency'` usages to `CurrencyDropdown` with the correct `currencyCodeListName` based on which SED type the component serves.

- **CurrencyDropdown default** changed from `euEftaValuta` to `verdensValuta` (most permissive — safe fallback)
- **F-SED-only components** (Motregninger, BeløpNavnOgValuta, SvarPaaAnmodningOmInntekt, Refusjon, InntektForeldreloeseBarnet): explicit `currencyCodeListName='euEftaValuta'`
- **U-SED-only components** (Inntekter, SisteAnsettelseInfo): explicit `currencyCodeListName='verdensValuta'`
- **Mixed components** (ForsikringPeriodeBox, InntektOgTimer): new `currencyCodeListName` prop, parent determines from `replySed.sedType` (U-SEDs → verdensValuta, F-SEDs → euEftaValuta)

## Verification

- TypeScript compilation passes (`tsc --noEmit`)
- Vite production build succeeds
- All CountrySelect currency usages replaced (15 files)