### PR TITLE
fix: validate that search input is numeric before querying rinasak (TEN-1577)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "13.7.0",
+  "version": "13.7.1-TEN-1577-VALIDATE-RINASAKID-INPUT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "13.7.0",
+      "version": "13.7.1-TEN-1577-VALIDATE-RINASAKID-INPUT",
       "dependencies": {
         "@navikt/aksel-icons": "8.9.0",
         "@navikt/ds-css": "8.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.7.0",
+  "version": "13.7.1-TEN-1577-VALIDATE-RINASAKID-INPUT",
   "private": true,
   "type": "module",
   "scripts": {
@@ -206,6 +206,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@13.7.0"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "13.7.1-TEN-1577-VALIDATE-RINASAKID-INPUT",
+  "version": "13.8.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -207,5 +207,5 @@
   ],
   "readme": "ERROR: No README data found!",
   "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@13.7.1-TEN-1577-VALIDATE-RINASAKID-INPUT"
+  "_id": "neessi@13.8.0"
 }

--- a/package.json
+++ b/package.json
@@ -206,5 +206,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@13.7.1-TEN-1577-VALIDATE-RINASAKID-INPUT"
 }

--- a/public/locales/nb/validation.json
+++ b/public/locales/nb/validation.json
@@ -121,6 +121,7 @@
   "noSaksId": "Du må velge fagsak",
   "noSaksnummer": "Du må taste inn et RINA saksnummer",
   "noSaksnummerOrFnr": "Ingen saksnummer eller f.nr./d.nr.",
+  "invalidSaksnummerOrFnr": "Søket må være et saksnummer (kun tall) eller et gyldig fødselsnummer/d-nummer",
   "noSedtype": "Du må velge SED type",
   "noSektor": "Du må velge sektor",
   "noSisteNavKontor": "Du må skrive inn siste NAV kontor",

--- a/src/applications/SvarSed/SEDQuery/validation.ts
+++ b/src/applications/SvarSed/SEDQuery/validation.ts
@@ -1,5 +1,5 @@
 import { Validation } from 'declarations/types'
-import { checkIfNotEmpty } from 'utils/validation'
+import { addError, checkIfNotEmpty } from 'utils/validation'
 
 interface ValidationSEDQueryProps {
   saksnummerOrFnr: string
@@ -12,9 +12,19 @@ export const validateSEDQuery = (
     saksnummerOrFnr
   }: ValidationSEDQueryProps
 ): boolean => {
-  return checkIfNotEmpty(v, {
+  const hasError = checkIfNotEmpty(v, {
     needle: saksnummerOrFnr,
     id: namespace + '-saksnummerOrFnr',
     message: 'validation:noSaksnummerOrFnr'
   })
+  if (hasError) return hasError
+
+  if (!/^\d+$/.test(saksnummerOrFnr)) {
+    return addError(v, {
+      id: namespace + '-saksnummerOrFnr',
+      message: 'validation:invalidSaksnummerOrFnr'
+    })
+  }
+
+  return false
 }


### PR DESCRIPTION
Resolves [TEN-1577](https://jira.adeo.no/browse/TEN-1577)

## Changes
- Extended `SEDQuery/validation.ts` to reject non-numeric input — the search field now only accepts digits (covers both saksnummer and fnr/dnr/npid)
- Added Norwegian validation message `invalidSaksnummerOrFnr` to translation file
- Previously, any text (full URLs, names) was sent as rinasakId to `/v5/rinasaker/{id}/oversikt`, causing unnecessary error propagation through eux-neessi → eux-rina-api → RINA

## Verification
- TypeScript typecheck passes
- Full build passes
- Validation triggers on non-numeric input, blocks submission, and shows clear error message
- Valid numeric input (saksnummer) and 11-digit fnr/dnr/npid still work as before