### PR TITLE
fix: correct aktivitet type typo permisjon_med/uten_lønn (TEN-1677)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "14.0.1",
+  "version": "14.0.2-TEN-1677-AKTIVITET-TYPE-TYPO",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "14.0.1",
+      "version": "14.0.2-TEN-1677-AKTIVITET-TYPE-TYPO",
       "dependencies": {
         "@navikt/aksel-icons": "8.9.0",
         "@navikt/ds-css": "8.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.0.1",
+  "version": "14.0.2-TEN-1677-AKTIVITET-TYPE-TYPO",
   "private": true,
   "type": "module",
   "scripts": {
@@ -203,6 +203,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@14.0.0"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/src/applications/SvarSed/AktivitetOgTrygdeperioder/AktivitetOgTrygdeperioder.tsx
+++ b/src/applications/SvarSed/AktivitetOgTrygdeperioder/AktivitetOgTrygdeperioder.tsx
@@ -194,10 +194,10 @@ const AktivitetOgTrygdeperioder: React.FC<MainFormProps> = ({
                       <Radio value='opphør_aktivitet_sykdom_med_lønn'>
                         {t('el:radio-aktivitet-type-mottar-loenn')}
                       </Radio>
-                      <Radio value='permisjon_med_lønnn'>
+                      <Radio value='permisjon_med_lønn'>
                         {t('el:radio-aktivitet-type-permisjon-med-loenn')}
                       </Radio>
-                      <Radio value='permisjon_uten_lønnn'>
+                      <Radio value='permisjon_uten_lønn'>
                         {t('el:radio-aktivitet-type-permisjon-uten-loenn')}
                       </Radio>
                     </RadioGroup>

--- a/src/applications/SvarSed/AktivitetOgTrygdeperioder/AktivitetStatusOgTrygdeperioder.tsx
+++ b/src/applications/SvarSed/AktivitetOgTrygdeperioder/AktivitetStatusOgTrygdeperioder.tsx
@@ -281,10 +281,10 @@ const AktivitetStatusOgTrygdeperioder: React.FC<MainFormProps> = ({
           <Radio value='opphør_aktivitet_sykdom_med_lønn'>
             {t('el:radio-aktivitet-type-mottar-loenn')}
           </Radio>
-          <Radio value='permisjon_med_lønnn'>
+          <Radio value='permisjon_med_lønn'>
             {t('el:radio-aktivitet-type-permisjon-med-loenn')}
           </Radio>
-          <Radio value='permisjon_uten_lønnn'>
+          <Radio value='permisjon_uten_lønn'>
             {t('el:radio-aktivitet-type-permisjon-uten-loenn')}
           </Radio>
         </RadioGroup>


### PR DESCRIPTION
Resolves [TEN-1677](https://jira.adeo.no/browse/TEN-1677)

## Changes
- Fixed typo in Radio values: `permisjon_med_lønnn` → `permisjon_med_lønn` and `permisjon_uten_lønnn` → `permisjon_uten_lønn` (triple n → double n)
- Affected files: `AktivitetStatusOgTrygdeperioder.tsx` and `AktivitetOgTrygdeperioder.tsx`

## Verification
- TypeScript type check passes
- Values now match CDM 4.4 codelist (`FTypeEmploymentType.properties`) in eux-rina-api