### PR TITLE
fix: add phone number format validation in F-SED (TEN-1601)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "14.0.2",
+  "version": "14.0.3-TEN-1601-TELEFON-VALIDERING",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "14.0.2",
+      "version": "14.0.3-TEN-1601-TELEFON-VALIDERING",
       "dependencies": {
         "@navikt/aksel-icons": "8.10.5",
         "@navikt/ds-css": "8.10.5",

--- a/package.json
+++ b/package.json
@@ -203,5 +203,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@14.0.3-TEN-1601-TELEFON-VALIDERING"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.0.3-TEN-1601-TELEFON-VALIDERING",
+  "version": "14.0.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -204,5 +204,5 @@
   ],
   "readme": "ERROR: No README data found!",
   "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@14.0.3-TEN-1601-TELEFON-VALIDERING"
+  "_id": "neessi@14.0.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.0.2",
+  "version": "14.0.3-TEN-1601-TELEFON-VALIDERING",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/locales/nb/validation.json
+++ b/public/locales/nb/validation.json
@@ -134,6 +134,7 @@
   "notInteger": "Kun heltall tillatt",
   "noInfoPresisering": "Ingen punktvise opplysninger oppgitt",
   "noTelephoneNumber": "Du må taste inn en telefonnummer",
+  "invalidTelephoneNumber": "Ugyldig telefonnummer. Bruk format: +XX XXXXXXXX",
   "noTelephoneType": "Du må velge en telefon type til",
   "noTema": "Du må velge et tema",
   "noTimer": "Mangler timer",

--- a/src/applications/SvarSed/Kontaktinformasjon/Kontaktinformasjon.tsx
+++ b/src/applications/SvarSed/Kontaktinformasjon/Kontaktinformasjon.tsx
@@ -284,7 +284,7 @@ const Kontaktinformasjon: React.FC<MainFormProps> = ({
         paddingBlock="space-8"
         paddingInline="space-16"
       >
-        <HGrid columns={3} gap="space-16">
+        <HGrid columns={3} gap="space-16" align="start">
           {inEditMode
             ? (
               <Input
@@ -367,7 +367,7 @@ const Kontaktinformasjon: React.FC<MainFormProps> = ({
         paddingBlock="space-8"
         paddingInline="space-16"
       >
-        <HStack gap="space-16">
+        <HStack gap="space-16" align="start">
           {inEditMode
             ? (
               <Input

--- a/src/applications/SvarSed/Kontaktinformasjon/validation.ts
+++ b/src/applications/SvarSed/Kontaktinformasjon/validation.ts
@@ -1,7 +1,7 @@
 import { Epost, Telefon } from 'declarations/sed'
 import { Validation } from 'declarations/types'
 import { getIdx } from 'utils/namespace'
-import { checkIfDuplicate, checkIfNotEmail, checkIfNotEmpty } from 'utils/validation'
+import { checkIfDuplicate, checkIfNotEmail, checkIfNotEmpty, checkPattern } from 'utils/validation'
 
 export interface ValidationKontaktsinformasjonTelefonProps {
   telefon: Telefon | undefined
@@ -51,6 +51,14 @@ export const validateKontaktsinformasjonTelefon = (
     needle: telefon?.nummer,
     id: namespace + idx + '-nummer',
     message: 'validation:noTelephoneNumber',
+    personName
+  }))
+
+  hasErrors.push(checkPattern(v, {
+    needle: telefon?.nummer,
+    id: namespace + idx + '-nummer',
+    pattern: /^((\+|00)?[0-9]{1,3}[. -]?([0-9]{1,3}[- .]?)([0-9][- .]?){5,10}[0-9])$/,
+    message: 'validation:invalidTelephoneNumber',
     personName
   }))
 


### PR DESCRIPTION
Resolves [TEN-1601](https://jira.adeo.no/browse/TEN-1601)

## Changes
- Added `checkPattern` validation with RINA's phone number regex to `validateKontaktsinformasjonTelefon`
- Added `invalidTelephoneNumber` translation key with user-friendly error message
- Prevents invalid phone numbers from being sent to RINA (which rejects with 412 PRECONDITION_FAILED)

## Verification
- TypeScript type check passes
- `checkPattern` skips validation when field is empty (no conflict with required-field check)
- Regex matches RINA's XSD phone validation pattern