### PR TITLE
fix: H120 DTO refactoring (TEN-1690)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "14.0.5",
+  "version": "14.1.0-TEN-1690-H120-DTO-REFACTORING",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "14.0.5",
+      "version": "14.1.0-TEN-1690-H120-DTO-REFACTORING",
       "dependencies": {
         "@navikt/aksel-icons": "8.11.1",
         "@navikt/ds-css": "8.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.0.5",
+  "version": "14.1.0-TEN-1690-H120-DTO-REFACTORING",
   "private": true,
   "type": "module",
   "scripts": {
@@ -203,6 +203,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@14.0.4"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/package.json
+++ b/package.json
@@ -203,5 +203,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@14.1.0-TEN-1690-H120-DTO-REFACTORING"
 }

--- a/src/applications/SvarSed/AWODSpoersmaal/AWODSpoersmaal.tsx
+++ b/src/applications/SvarSed/AWODSpoersmaal/AWODSpoersmaal.tsx
@@ -68,76 +68,76 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
   })
 
   const setType = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.type', value.trim()))
+    dispatch(updateReplySed('yrkesskade.type', value.trim()))
     if (validation[namespace + '-type']) {
       dispatch(resetValidation(namespace + '-type'))
     }
   }
 
   const setDato = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.dato', value.trim()))
+    dispatch(updateReplySed('yrkesskade.dato', value.trim()))
   }
 
   const setBrukerStatus = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.brukerStatus', value.trim()))
+    dispatch(updateReplySed('yrkesskade.brukerStatus', value.trim()))
     if (value !== 'annet') {
-      dispatch(updateReplySed('arbeidsulykkeyrkessykdom.brukerStatusAnnet', undefined))
+      dispatch(updateReplySed('yrkesskade.brukerStatusAnnet', undefined))
     }
   }
 
   const setBrukerStatusAnnet = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.brukerStatusAnnet', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.brukerStatusAnnet', value.trim() || undefined))
   }
 
   const setSykdomKode = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.sykdomKode', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.sykdomKode', value.trim() || undefined))
   }
 
   const setSykdomKodingssystem = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.sykdomKodingssystem', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.sykdomKodingssystem', value.trim() || undefined))
   }
 
   const setKonsekvensEllerBeskrivelse = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.konsekvensEllerBeskrivelse', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.konsekvensEllerBeskrivelse', value.trim() || undefined))
   }
 
   const setArbeidsgiverNavn = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.navn', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.navn', value.trim() || undefined))
   }
 
   const setArbeidsgiverGate = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.adresse.gate', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.adresse.gate', value.trim() || undefined))
   }
 
   const setArbeidsgiverBygning = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.adresse.bygning', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.adresse.bygning', value.trim() || undefined))
   }
 
   const setArbeidsgiverPostnummer = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.adresse.postnummer', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.adresse.postnummer', value.trim() || undefined))
   }
 
   const setArbeidsgiverBy = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.adresse.by', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.adresse.by', value.trim() || undefined))
   }
 
   const setArbeidsgiverRegion = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.adresse.region', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.adresse.region', value.trim() || undefined))
   }
 
   const setArbeidsgiverLandkode = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.adresse.landkode', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.adresse.landkode', value.trim() || undefined))
   }
 
   const setIdentifikatorType = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.identifikator[0].type', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.identifikator[0].type', value.trim() || undefined))
   }
 
   const setIdentifikatorId = (value: string) => {
-    dispatch(updateReplySed('arbeidsulykkeyrkessykdom.arbeidsgiver.identifikator[0].id', value.trim() || undefined))
+    dispatch(updateReplySed('yrkesskade.arbeidsgiver.identifikator[0].id', value.trim() || undefined))
   }
 
-  const awod = sed.arbeidsulykkeyrkessykdom
+  const awod = sed.yrkesskade
   const adresse = awod?.arbeidsgiver?.adresse
   const hasAnyAdresseField = !!(
     adresse?.gate?.trim() || adresse?.bygning?.trim() || adresse?.postnummer?.trim() ||
@@ -169,8 +169,8 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
           menuPortalTarget={document.body}
           onChange={(o: unknown) => setType((o as Option).value)}
           options={awodTypeOptions}
-          value={_.find(awodTypeOptions, o => o.value === sed.arbeidsulykkeyrkessykdom?.type)}
-          defaultValue={_.find(awodTypeOptions, o => o.value === sed.arbeidsulykkeyrkessykdom?.type)}
+          value={_.find(awodTypeOptions, o => o.value === sed.yrkesskade?.type)}
+          defaultValue={_.find(awodTypeOptions, o => o.value === sed.yrkesskade?.type)}
         />
 
         <HStack>
@@ -180,7 +180,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             namespace={namespace}
             label={t('label:dato-for-ulykken-sykdommen') + (hasAnyAWODField ? ' *' : '')}
             onChanged={setDato}
-            dateValue={sed.arbeidsulykkeyrkessykdom?.dato}
+            dateValue={sed.yrkesskade?.dato}
           />
         </HStack>
 
@@ -191,11 +191,11 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
           menuPortalTarget={document.body}
           onChange={(o: unknown) => setBrukerStatus((o as Option).value)}
           options={brukerStatusOptions}
-          value={_.find(brukerStatusOptions, o => o.value === sed.arbeidsulykkeyrkessykdom?.brukerStatus)}
-          defaultValue={_.find(brukerStatusOptions, o => o.value === sed.arbeidsulykkeyrkessykdom?.brukerStatus)}
+          value={_.find(brukerStatusOptions, o => o.value === sed.yrkesskade?.brukerStatus)}
+          defaultValue={_.find(brukerStatusOptions, o => o.value === sed.yrkesskade?.brukerStatus)}
         />
 
-        {sed.arbeidsulykkeyrkessykdom?.brukerStatus === 'annet' && (
+        {sed.yrkesskade?.brukerStatus === 'annet' && (
           <TextArea
             error={validation[namespace + '-brukerStatusAnnet']?.feilmelding}
             namespace={namespace}
@@ -203,7 +203,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             label={t('label:angi-status-annet')}
             maxLength={65}
             onChanged={setBrukerStatusAnnet}
-            value={sed.arbeidsulykkeyrkessykdom?.brukerStatusAnnet}
+            value={sed.yrkesskade?.brukerStatusAnnet}
           />
         )}
 
@@ -214,7 +214,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='sykdomKode'
             label={t('label:kode-arbeidsulykke-yrkessykdom')}
             onChanged={setSykdomKode}
-            value={sed.arbeidsulykkeyrkessykdom?.sykdomKode}
+            value={sed.yrkesskade?.sykdomKode}
           />
           <Input
             error={validation[namespace + '-sykdomKodingssystem']?.feilmelding}
@@ -222,7 +222,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='sykdomKodingssystem'
             label={t('label:kodingssystem')}
             onChanged={setSykdomKodingssystem}
-            value={sed.arbeidsulykkeyrkessykdom?.sykdomKodingssystem}
+            value={sed.yrkesskade?.sykdomKodingssystem}
           />
         </HGrid>
 
@@ -233,7 +233,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
           label={t('label:konsekvenser-eller-beskrivelse')}
           maxLength={255}
           onChanged={setKonsekvensEllerBeskrivelse}
-          value={sed.arbeidsulykkeyrkessykdom?.konsekvensEllerBeskrivelse}
+          value={sed.yrkesskade?.konsekvensEllerBeskrivelse}
         />
 
         <Heading size='xsmall'>
@@ -245,7 +245,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
           id='arbeidsgiverNavn'
           label={t('label:arbeidsgiver-navn') + (hasAnyAWODField ? ' *' : '')}
           onChanged={setArbeidsgiverNavn}
-          value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.navn}
+          value={sed.yrkesskade?.arbeidsgiver?.navn}
         />
         <HGrid columns={2} gap="space-16" align="start">
           <Input
@@ -254,7 +254,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='identifikatorId'
             label={t('label:arbeidsgiver-identifikator-id') + (hasAnyIdentifikatorField ? ' *' : '')}
             onChanged={setIdentifikatorId}
-            value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.identifikator?.[0]?.id}
+            value={sed.yrkesskade?.arbeidsgiver?.identifikator?.[0]?.id}
           />
           <Select
             data-testid={namespace + '-identifikatorType'}
@@ -264,8 +264,8 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             menuPortalTarget={document.body}
             onChange={(o: unknown) => setIdentifikatorType((o as Option).value)}
             options={identifikatorTypeOptions}
-            value={_.find(identifikatorTypeOptions, o => o.value === sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.identifikator?.[0]?.type)}
-            defaultValue={_.find(identifikatorTypeOptions, o => o.value === sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.identifikator?.[0]?.type)}
+            value={_.find(identifikatorTypeOptions, o => o.value === sed.yrkesskade?.arbeidsgiver?.identifikator?.[0]?.type)}
+            defaultValue={_.find(identifikatorTypeOptions, o => o.value === sed.yrkesskade?.arbeidsgiver?.identifikator?.[0]?.type)}
           />
         </HGrid>
         <HGrid columns={"2fr 1fr"} gap="space-16">
@@ -275,7 +275,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='arbeidsgiverGate'
             label={t('label:gateadresse')}
             onChanged={setArbeidsgiverGate}
-            value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.adresse?.gate}
+            value={sed.yrkesskade?.arbeidsgiver?.adresse?.gate}
           />
           <Input
             error={undefined}
@@ -283,7 +283,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='arbeidsgiverBygning'
             label={t('label:bygning')}
             onChanged={setArbeidsgiverBygning}
-            value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.adresse?.bygning}
+            value={sed.yrkesskade?.arbeidsgiver?.adresse?.bygning}
           />
         </HGrid>
         <HGrid columns={4} gap="space-16" align="start">
@@ -293,7 +293,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='arbeidsgiverPostnummer'
             label={t('label:postnr')}
             onChanged={setArbeidsgiverPostnummer}
-            value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.adresse?.postnummer}
+            value={sed.yrkesskade?.arbeidsgiver?.adresse?.postnummer}
           />
           <Input
             error={validation[namespace + '-arbeidsgiverBy']?.feilmelding}
@@ -301,7 +301,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='arbeidsgiverBy'
             label={t('label:by') + (hasAnyAdresseField ? ' *' : '')}
             onChanged={setArbeidsgiverBy}
-            value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.adresse?.by}
+            value={sed.yrkesskade?.arbeidsgiver?.adresse?.by}
           />
           <Input
             error={undefined}
@@ -309,7 +309,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
             id='arbeidsgiverRegion'
             label={t('label:region')}
             onChanged={setArbeidsgiverRegion}
-            value={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.adresse?.region}
+            value={sed.yrkesskade?.arbeidsgiver?.adresse?.region}
           />
           <div style={{ maxWidth: '400px' }}>
             <CountryDropdown
@@ -322,7 +322,7 @@ const AWODSpoersmaal: React.FC<MainFormProps> = ({
               label={t('label:land') + (hasAnyAdresseField ? ' *' : '')}
               menuPortalTarget={document.body}
               onOptionSelected={(e: Country) => setArbeidsgiverLandkode(e.value3)}
-              values={sed.arbeidsulykkeyrkessykdom?.arbeidsgiver?.adresse?.landkode}
+              values={sed.yrkesskade?.arbeidsgiver?.adresse?.landkode}
             />
           </div>
         </HGrid>

--- a/src/applications/SvarSed/AWODSpoersmaal/validation.ts
+++ b/src/applications/SvarSed/AWODSpoersmaal/validation.ts
@@ -20,7 +20,7 @@ export const validateAWODSpoersmaal = (
   const sed = replySed as H120Sed
 
   hasErrors.push(checkLength(v, {
-    needle: sed.arbeidsulykkeyrkessykdom?.brukerStatusAnnet,
+    needle: sed.yrkesskade?.brukerStatusAnnet,
     max: 65,
     id: namespace + '-brukerStatusAnnet',
     message: 'validation:textOverX',
@@ -28,7 +28,7 @@ export const validateAWODSpoersmaal = (
   }))
 
   hasErrors.push(checkLength(v, {
-    needle: sed.arbeidsulykkeyrkessykdom?.sykdomKode,
+    needle: sed.yrkesskade?.sykdomKode,
     max: 25,
     id: namespace + '-sykdomKode',
     message: 'validation:textOverX',
@@ -36,7 +36,7 @@ export const validateAWODSpoersmaal = (
   }))
 
   hasErrors.push(checkLength(v, {
-    needle: sed.arbeidsulykkeyrkessykdom?.sykdomKodingssystem,
+    needle: sed.yrkesskade?.sykdomKodingssystem,
     max: 65,
     id: namespace + '-sykdomKodingssystem',
     message: 'validation:textOverX',
@@ -44,14 +44,14 @@ export const validateAWODSpoersmaal = (
   }))
 
   hasErrors.push(checkLength(v, {
-    needle: sed.arbeidsulykkeyrkessykdom?.konsekvensEllerBeskrivelse,
+    needle: sed.yrkesskade?.konsekvensEllerBeskrivelse,
     max: 255,
     id: namespace + '-konsekvensEllerBeskrivelse',
     message: 'validation:textOverX',
     personName
   }))
 
-  const awod = sed.arbeidsulykkeyrkessykdom
+  const awod = sed.yrkesskade
   const adresse = awod?.arbeidsgiver?.adresse
   const hasAnyAdresseField = !!(
     adresse?.gate?.trim() || adresse?.bygning?.trim() || adresse?.postnummer?.trim() ||

--- a/src/applications/SvarSed/Adresser/Adresse.tsx
+++ b/src/applications/SvarSed/Adresser/Adresse.tsx
@@ -22,14 +22,15 @@ const Adresse: React.FC<MainFormProps> = ({
   personID,
   personName,
   replySed,
-  updateReplySed
+  updateReplySed,
+  formValue
 }: MainFormProps): JSX.Element => {
   const { validation }: MainFormSelector = useAppSelector(mapState)
   const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const target = `${personID}.adresse`
   const adresse: IAdresse | undefined = _.get(replySed, target)
-  const namespace = `${parentNamespace}-${personID}-adresse`
+  const namespace = `${parentNamespace}-${personID}-${formValue ?? 'adresse'}`
 
   useUnmount(() => {
     const clonedvalidation = _.cloneDeep(validation)

--- a/src/applications/SvarSed/Adresser/Adresse.tsx
+++ b/src/applications/SvarSed/Adresser/Adresse.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
 import AdresseForm from 'applications/SvarSed/Adresser/AdresseForm'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
-import { validateAdresseH120, ValidationAdresseH120Props } from './validation'
+import { validateAdresse, ValidationAdresseProps } from './validation'
 
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
@@ -34,9 +34,11 @@ const Adresse: React.FC<MainFormProps> = ({
 
   useUnmount(() => {
     const clonedvalidation = _.cloneDeep(validation)
-    performValidation<ValidationAdresseH120Props>(
-      clonedvalidation, namespace, validateAdresseH120, {
+    performValidation<ValidationAdresseProps>(
+      clonedvalidation, namespace, validateAdresse, {
         adresse,
+        checkAdresseType: false,
+        optional: true,
         personName
       }, true
     )

--- a/src/applications/SvarSed/Adresser/Adresse.tsx
+++ b/src/applications/SvarSed/Adresser/Adresse.tsx
@@ -1,27 +1,46 @@
-import { resetValidation } from 'actions/validation'
+import { Box, Heading, VStack } from '@navikt/ds-react'
+import { resetValidation, setValidation } from 'actions/validation'
 import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
 import { State } from 'declarations/reducers'
 import { Adresse as IAdresse } from 'declarations/sed'
+import useUnmount from 'hooks/useUnmount'
 import _ from 'lodash'
 import React, { JSX } from 'react';
+import { useTranslation } from 'react-i18next'
 import AdresseForm from 'applications/SvarSed/Adresser/AdresseForm'
 import { useAppDispatch, useAppSelector } from 'store'
+import performValidation from 'utils/performValidation'
+import { validateAdresseH120, ValidationAdresseH120Props } from './validation'
 
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
 
 const Adresse: React.FC<MainFormProps> = ({
+  label,
   parentNamespace,
   personID,
+  personName,
   replySed,
   updateReplySed
 }: MainFormProps): JSX.Element => {
   const { validation }: MainFormSelector = useAppSelector(mapState)
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const target = `${personID}.adresse`
   const adresse: IAdresse | undefined = _.get(replySed, target)
   const namespace = `${parentNamespace}-${personID}-adresse`
+
+  useUnmount(() => {
+    const clonedvalidation = _.cloneDeep(validation)
+    performValidation<ValidationAdresseH120Props>(
+      clonedvalidation, namespace, validateAdresseH120, {
+        adresse,
+        personName
+      }, true
+    )
+    dispatch(setValidation(clonedvalidation))
+  })
 
   const setAdresse = (adresse: IAdresse, whatChanged: string | undefined) => {
     dispatch(updateReplySed(target, adresse))
@@ -31,15 +50,22 @@ const Adresse: React.FC<MainFormProps> = ({
   }
 
   return (
-    <AdresseForm
-      type={false}
-      options={{ bygning: true, region: true }}
-      required={['by', 'land']}
-      namespace={namespace}
-      adresse={adresse}
-      onAdressChanged={setAdresse}
-      validation={validation}
-    />
+    <Box padding="space-16">
+      <VStack gap="space-16">
+        <Heading size='small'>
+          {label}
+        </Heading>
+        <AdresseForm
+          type={false}
+          options={{ bygning: true, region: true }}
+          required={['by', 'land']}
+          namespace={namespace}
+          adresse={adresse}
+          onAdressChanged={setAdresse}
+          validation={validation}
+        />
+      </VStack>
+    </Box>
   )
 }
 

--- a/src/applications/SvarSed/Adresser/Adresse.tsx
+++ b/src/applications/SvarSed/Adresser/Adresse.tsx
@@ -1,0 +1,46 @@
+import { resetValidation } from 'actions/validation'
+import { MainFormProps, MainFormSelector } from 'applications/SvarSed/MainForm'
+import { State } from 'declarations/reducers'
+import { Adresse as IAdresse } from 'declarations/sed'
+import _ from 'lodash'
+import React, { JSX } from 'react';
+import AdresseForm from 'applications/SvarSed/Adresser/AdresseForm'
+import { useAppDispatch, useAppSelector } from 'store'
+
+const mapState = (state: State): MainFormSelector => ({
+  validation: state.validation.status
+})
+
+const Adresse: React.FC<MainFormProps> = ({
+  parentNamespace,
+  personID,
+  replySed,
+  updateReplySed
+}: MainFormProps): JSX.Element => {
+  const { validation }: MainFormSelector = useAppSelector(mapState)
+  const dispatch = useAppDispatch()
+  const target = `${personID}.adresse`
+  const adresse: IAdresse | undefined = _.get(replySed, target)
+  const namespace = `${parentNamespace}-${personID}-adresse`
+
+  const setAdresse = (adresse: IAdresse, whatChanged: string | undefined) => {
+    dispatch(updateReplySed(target, adresse))
+    if (whatChanged && validation[namespace + '-' + whatChanged]) {
+      dispatch(resetValidation(namespace + '-' + whatChanged))
+    }
+  }
+
+  return (
+    <AdresseForm
+      type={false}
+      options={{ bygning: true, region: true }}
+      required={['by', 'land']}
+      namespace={namespace}
+      adresse={adresse}
+      onAdressChanged={setAdresse}
+      validation={validation}
+    />
+  )
+}
+
+export default Adresse

--- a/src/applications/SvarSed/Adresser/validation.ts
+++ b/src/applications/SvarSed/Adresser/validation.ts
@@ -111,6 +111,80 @@ export const validateAdresser = (
   return hasErrors.find(value => value) !== undefined
 }
 
+export interface ValidationAdresseH120Props {
+  adresse: Adresse | undefined
+  personName?: string
+}
+
+export const validateAdresseH120 = (
+  v: Validation,
+  namespace: string,
+  {
+    adresse,
+    personName
+  }: ValidationAdresseH120Props
+): boolean => {
+  const hasErrors: Array<boolean> = []
+
+  const hasAnyField = !!(
+    adresse?.gate?.trim() || adresse?.bygning?.trim() || adresse?.postnummer?.trim() ||
+    adresse?.by?.trim() || adresse?.region?.trim() || adresse?.landkode?.trim()
+  )
+
+  if (hasAnyField) {
+    hasErrors.push(checkIfNotEmpty(v, {
+      needle: adresse?.by,
+      id: namespace + '-by',
+      message: 'validation:noAddressCity',
+      personName
+    }))
+
+    hasErrors.push(checkIfNotEmpty(v, {
+      needle: adresse?.landkode,
+      id: namespace + '-land',
+      message: 'validation:noAddressCountry',
+      personName
+    }))
+  }
+
+  hasErrors.push(checkLength(v, {
+    needle: adresse?.gate,
+    id: namespace + '-gate',
+    max: 155,
+    message: 'validation:textOverX'
+  }))
+
+  hasErrors.push(checkLength(v, {
+    needle: adresse?.bygning,
+    id: namespace + '-bygning',
+    max: 155,
+    message: 'validation:textOverX'
+  }))
+
+  hasErrors.push(checkLength(v, {
+    needle: adresse?.by,
+    id: namespace + '-by',
+    max: 65,
+    message: 'validation:textOverX'
+  }))
+
+  hasErrors.push(checkLength(v, {
+    needle: adresse?.postnummer,
+    id: namespace + '-postnummer',
+    max: 25,
+    message: 'validation:textOverX'
+  }))
+
+  hasErrors.push(checkLength(v, {
+    needle: adresse?.region,
+    id: namespace + '-region',
+    max: 65,
+    message: 'validation:textOverX'
+  }))
+
+  return hasErrors.find(value => value) !== undefined
+}
+
 export const validateAnmodningOmAdresse = ({}: any): boolean => {
   const hasErrors: Array<boolean> = []
 

--- a/src/applications/SvarSed/Adresser/validation.ts
+++ b/src/applications/SvarSed/Adresser/validation.ts
@@ -8,6 +8,7 @@ export interface ValidationAdresseProps {
   index?: number
   checkAdresseType: boolean
   personName?: string
+  optional?: boolean
 }
 
 export interface ValidationAdresserProps {
@@ -23,34 +24,42 @@ export const validateAdresse = (
     adresse,
     index,
     checkAdresseType,
-    personName
+    personName,
+    optional
   }: ValidationAdresseProps
 ): boolean => {
   const hasErrors: Array<boolean> = []
   const idx = getIdx(index)
 
-  if (checkAdresseType) {
+  const hasAnyField = !!(
+    adresse?.gate?.trim() || adresse?.bygning?.trim() || adresse?.postnummer?.trim() ||
+    adresse?.by?.trim() || adresse?.region?.trim() || adresse?.landkode?.trim()
+  )
+
+  if (!optional || hasAnyField) {
+    if (checkAdresseType) {
+      hasErrors.push(checkIfNotEmpty(v, {
+        needle: adresse?.type,
+        id: namespace + idx + '-type',
+        message: 'validation:noAddressType',
+        personName
+      }))
+    }
+
     hasErrors.push(checkIfNotEmpty(v, {
-      needle: adresse?.type,
-      id: namespace + idx + '-type',
-      message: 'validation:noAddressType',
+      needle: adresse?.landkode,
+      id: namespace + idx + '-land',
+      message: 'validation:noAddressCountry',
+      personName
+    }))
+
+    hasErrors.push(checkIfNotEmpty(v, {
+      needle: adresse?.by,
+      id: namespace + idx + '-by',
+      message: 'validation:noAddressCity',
       personName
     }))
   }
-
-  hasErrors.push(checkIfNotEmpty(v, {
-    needle: adresse?.landkode,
-    id: namespace + idx + '-land',
-    message: 'validation:noAddressCountry',
-    personName
-  }))
-
-  hasErrors.push(checkIfNotEmpty(v, {
-    needle: adresse?.by,
-    id: namespace + idx + '-by',
-    message: 'validation:noAddressCity',
-    personName
-  }))
 
   hasErrors.push(checkLength(v, {
     needle: adresse?.gate,
@@ -108,80 +117,6 @@ export const validateAdresser = (
       personName
     }))
   })
-  return hasErrors.find(value => value) !== undefined
-}
-
-export interface ValidationAdresseH120Props {
-  adresse: Adresse | undefined
-  personName?: string
-}
-
-export const validateAdresseH120 = (
-  v: Validation,
-  namespace: string,
-  {
-    adresse,
-    personName
-  }: ValidationAdresseH120Props
-): boolean => {
-  const hasErrors: Array<boolean> = []
-
-  const hasAnyField = !!(
-    adresse?.gate?.trim() || adresse?.bygning?.trim() || adresse?.postnummer?.trim() ||
-    adresse?.by?.trim() || adresse?.region?.trim() || adresse?.landkode?.trim()
-  )
-
-  if (hasAnyField) {
-    hasErrors.push(checkIfNotEmpty(v, {
-      needle: adresse?.by,
-      id: namespace + '-by',
-      message: 'validation:noAddressCity',
-      personName
-    }))
-
-    hasErrors.push(checkIfNotEmpty(v, {
-      needle: adresse?.landkode,
-      id: namespace + '-land',
-      message: 'validation:noAddressCountry',
-      personName
-    }))
-  }
-
-  hasErrors.push(checkLength(v, {
-    needle: adresse?.gate,
-    id: namespace + '-gate',
-    max: 155,
-    message: 'validation:textOverX'
-  }))
-
-  hasErrors.push(checkLength(v, {
-    needle: adresse?.bygning,
-    id: namespace + '-bygning',
-    max: 155,
-    message: 'validation:textOverX'
-  }))
-
-  hasErrors.push(checkLength(v, {
-    needle: adresse?.by,
-    id: namespace + '-by',
-    max: 65,
-    message: 'validation:textOverX'
-  }))
-
-  hasErrors.push(checkLength(v, {
-    needle: adresse?.postnummer,
-    id: namespace + '-postnummer',
-    max: 25,
-    message: 'validation:textOverX'
-  }))
-
-  hasErrors.push(checkLength(v, {
-    needle: adresse?.region,
-    id: namespace + '-region',
-    max: 65,
-    message: 'validation:textOverX'
-  }))
-
   return hasErrors.find(value => value) !== undefined
 }
 

--- a/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
+++ b/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
@@ -19,10 +19,10 @@ const mapState = (state: State): MainFormSelector => ({
 })
 
 const deriveGjelderArbeidsufoerhet = (sed: H120Sed): string => {
-  if (sed.arbeidsufoer?.periodeStartdato || sed.arbeidsufoer?.periodeSluttdato) {
+  if (sed.arbeidsufoer !== undefined) {
     return 'ja'
   }
-  if (sed.arbeidsdyktig?.dekkesKostnader) {
+  if (sed.arbeidsdyktig !== undefined) {
     return 'nei'
   }
   return ''
@@ -67,8 +67,14 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
     setGjelderArbeidsufoerhetState(value)
     if (value === 'ja') {
       dispatch(updateReplySed('arbeidsdyktig', undefined))
+      if (!sed.arbeidsufoer) {
+        dispatch(updateReplySed('arbeidsufoer', {}))
+      }
     } else {
       dispatch(updateReplySed('arbeidsufoer', undefined))
+      if (!sed.arbeidsdyktig) {
+        dispatch(updateReplySed('arbeidsdyktig', {}))
+      }
     }
     if (validation[namespace + '-gjelderArbeidsufoerhet']) {
       dispatch(resetValidation(namespace + '-gjelderArbeidsufoerhet'))

--- a/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
+++ b/src/applications/SvarSed/AnmodningInfo/AnmodningInfo.tsx
@@ -10,13 +10,23 @@ import { State } from 'declarations/reducers'
 import { H120Sed } from 'declarations/h120'
 import useUnmount from 'hooks/useUnmount'
 import _ from 'lodash'
-import React, { JSX } from 'react';
+import React, { useState, JSX } from 'react';
 import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from 'store'
 import performValidation from 'utils/performValidation'
 const mapState = (state: State): MainFormSelector => ({
   validation: state.validation.status
 })
+
+const deriveGjelderArbeidsufoerhet = (sed: H120Sed): string => {
+  if (sed.arbeidsufoer?.periodeStartdato || sed.arbeidsufoer?.periodeSluttdato) {
+    return 'ja'
+  }
+  if (sed.arbeidsdyktig?.dekkesKostnader) {
+    return 'nei'
+  }
+  return ''
+}
 
 const AnmodningInfo: React.FC<MainFormProps> = ({
   label,
@@ -32,7 +42,11 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
   const namespace = `${parentNamespace}-${personID}-anmodninginfo`
   const sed = replySed as H120Sed
 
-  const dekningKostnaderOptions: Options = [
+  const [gjelderArbeidsufoerhet, setGjelderArbeidsufoerhetState] = useState<string>(
+    () => deriveGjelderArbeidsufoerhet(sed)
+  )
+
+  const dekkesKostnaderOptions: Options = [
     { label: t('el:option-h120-dekningkostnader-ja'), value: 'ja' },
     { label: t('el:option-h120-dekningkostnader-nei'), value: 'nei' },
     { label: t('el:option-h120-dekningkostnader-gjelder_ikke'), value: 'gjelder_ikke' }
@@ -50,11 +64,11 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
   })
 
   const setGjelderArbeidsufoerhet = (value: string) => {
-    const boolValue = value === 'ja'
-    dispatch(updateReplySed('anmodningInfo.gjelderArbeidsufoerhet', boolValue))
-    if (!boolValue) {
-      dispatch(updateReplySed('anmodningInfo.periodeStartdato', undefined))
-      dispatch(updateReplySed('anmodningInfo.periodeSluttdato', undefined))
+    setGjelderArbeidsufoerhetState(value)
+    if (value === 'ja') {
+      dispatch(updateReplySed('arbeidsdyktig', undefined))
+    } else {
+      dispatch(updateReplySed('arbeidsufoer', undefined))
     }
     if (validation[namespace + '-gjelderArbeidsufoerhet']) {
       dispatch(resetValidation(namespace + '-gjelderArbeidsufoerhet'))
@@ -62,27 +76,30 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
   }
 
   const setPeriodeStartdato = (value: string) => {
-    dispatch(updateReplySed('anmodningInfo.periodeStartdato', value.trim()))
+    dispatch(updateReplySed('arbeidsufoer.periodeStartdato', value.trim()))
     if (validation[namespace + '-startdato']) {
       dispatch(resetValidation(namespace + '-startdato'))
     }
   }
 
   const setPeriodeSluttdato = (value: string) => {
-    dispatch(updateReplySed('anmodningInfo.periodeSluttdato', value.trim()))
+    dispatch(updateReplySed('arbeidsufoer.periodeSluttdato', value.trim()))
     if (validation[namespace + '-sluttdato']) {
       dispatch(resetValidation(namespace + '-sluttdato'))
     }
   }
 
-  const setDekningKostnader = (value: string) => {
-    dispatch(updateReplySed('anmodningInfo.dekningKostnader', value.trim()))
-    if (validation[namespace + '-dekningKostnader']) {
-      dispatch(resetValidation(namespace + '-dekningKostnader'))
+  const setDekkesKostnader = (value: string) => {
+    const target = gjelderArbeidsufoerhet === 'ja' ? 'arbeidsufoer.dekkesKostnader' : 'arbeidsdyktig.dekkesKostnader'
+    dispatch(updateReplySed(target, value.trim()))
+    if (validation[namespace + '-dekkesKostnader']) {
+      dispatch(resetValidation(namespace + '-dekkesKostnader'))
     }
   }
 
-  const gjelderArbeidsufoerhet = sed.anmodningInfo?.gjelderArbeidsufoerhet
+  const currentDekkesKostnader = gjelderArbeidsufoerhet === 'ja'
+    ? sed.arbeidsufoer?.dekkesKostnader
+    : sed.arbeidsdyktig?.dekkesKostnader
 
   return (
     <Box padding="space-16">
@@ -92,7 +109,7 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
         </Heading>
 
         <RadioGroup
-          value={gjelderArbeidsufoerhet === true ? 'ja' : gjelderArbeidsufoerhet === false ? 'nei' : ''}
+          value={gjelderArbeidsufoerhet}
           data-no-border
           data-testid={namespace + '-gjelderArbeidsufoerhet'}
           error={validation[namespace + '-gjelderArbeidsufoerhet']?.feilmelding}
@@ -111,7 +128,7 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
           </HStack>
         </RadioGroup>
 
-        {gjelderArbeidsufoerhet === true && (
+        {gjelderArbeidsufoerhet === 'ja' && (
           <HGrid columns={2} gap="space-16" align="start">
             <DateField
               error={validation[namespace + '-startdato']?.feilmelding}
@@ -120,7 +137,7 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
               label={t('label:startdato-arbeidsufoerhet')}
               onChanged={setPeriodeStartdato}
               required
-              dateValue={sed.anmodningInfo?.periodeStartdato}
+              dateValue={sed.arbeidsufoer?.periodeStartdato}
             />
             <DateField
               error={validation[namespace + '-sluttdato']?.feilmelding}
@@ -129,23 +146,25 @@ const AnmodningInfo: React.FC<MainFormProps> = ({
               label={t('label:sluttdato-arbeidsufoerhet')}
               onChanged={setPeriodeSluttdato}
               required
-              dateValue={sed.anmodningInfo?.periodeSluttdato}
+              dateValue={sed.arbeidsufoer?.periodeSluttdato}
             />
           </HGrid>
         )}
 
-        <Select
-          data-testid={namespace + '-dekningKostnader'}
-          error={validation[namespace + '-dekningKostnader']?.feilmelding}
-          id={namespace + '-dekningKostnader'}
-          label={t('label:dekking-av-kostnader')}
-          menuPortalTarget={document.body}
-          onChange={(o: unknown) => setDekningKostnader((o as Option).value)}
-          options={dekningKostnaderOptions}
-          required
-          value={_.find(dekningKostnaderOptions, o => o.value === sed.anmodningInfo?.dekningKostnader)}
-          defaultValue={_.find(dekningKostnaderOptions, o => o.value === sed.anmodningInfo?.dekningKostnader)}
-        />
+        {gjelderArbeidsufoerhet !== '' && (
+          <Select
+            data-testid={namespace + '-dekkesKostnader'}
+            error={validation[namespace + '-dekkesKostnader']?.feilmelding}
+            id={namespace + '-dekkesKostnader'}
+            label={t('label:dekking-av-kostnader')}
+            menuPortalTarget={document.body}
+            onChange={(o: unknown) => setDekkesKostnader((o as Option).value)}
+            options={dekkesKostnaderOptions}
+            required
+            value={_.find(dekkesKostnaderOptions, o => o.value === currentDekkesKostnader)}
+            defaultValue={_.find(dekkesKostnaderOptions, o => o.value === currentDekkesKostnader)}
+          />
+        )}
       </VStack>
     </Box>
   )

--- a/src/applications/SvarSed/AnmodningInfo/validation.ts
+++ b/src/applications/SvarSed/AnmodningInfo/validation.ts
@@ -20,7 +20,11 @@ export const validateAnmodningInfo = (
   const hasErrors: Array<boolean> = []
   const sed = replySed as H120Sed
 
-  if (sed.anmodningInfo?.gjelderArbeidsufoerhet === undefined || sed.anmodningInfo?.gjelderArbeidsufoerhet === null) {
+  const isArbeidsufoer = !!(sed.arbeidsufoer?.periodeStartdato || sed.arbeidsufoer?.periodeSluttdato)
+  const isArbeidsdyktig = !!sed.arbeidsdyktig?.dekkesKostnader
+  const hasSelection = isArbeidsufoer || isArbeidsdyktig
+
+  if (!hasSelection) {
     hasErrors.push(checkIfNotEmpty(v, {
       needle: undefined,
       id: namespace + '-gjelderArbeidsufoerhet',
@@ -29,24 +33,33 @@ export const validateAnmodningInfo = (
     }))
   }
 
-  if (sed.anmodningInfo?.gjelderArbeidsufoerhet === true) {
+  if (isArbeidsufoer) {
     hasErrors.push(validatePeriode(v, namespace, {
       periode: {
-        startdato: sed.anmodningInfo?.periodeStartdato ?? '',
-        sluttdato: sed.anmodningInfo?.periodeSluttdato ?? ''
+        startdato: sed.arbeidsufoer?.periodeStartdato ?? '',
+        sluttdato: sed.arbeidsufoer?.periodeSluttdato ?? ''
       },
       mandatoryStartdato: true,
       mandatorySluttdato: true,
       periodeType: 'simple'
     }))
+
+    hasErrors.push(checkIfNotEmpty(v, {
+      needle: sed.arbeidsufoer?.dekkesKostnader,
+      id: namespace + '-dekkesKostnader',
+      message: 'validation:noDekningKostnader',
+      personName
+    }))
   }
 
-  hasErrors.push(checkIfNotEmpty(v, {
-    needle: sed.anmodningInfo?.dekningKostnader,
-    id: namespace + '-dekningKostnader',
-    message: 'validation:noDekningKostnader',
-    personName
-  }))
+  if (isArbeidsdyktig) {
+    hasErrors.push(checkIfNotEmpty(v, {
+      needle: sed.arbeidsdyktig?.dekkesKostnader,
+      id: namespace + '-dekkesKostnader',
+      message: 'validation:noDekningKostnader',
+      personName
+    }))
+  }
 
   return hasErrors.find(value => value) !== undefined
 }

--- a/src/applications/SvarSed/AnmodningInfo/validation.ts
+++ b/src/applications/SvarSed/AnmodningInfo/validation.ts
@@ -20,8 +20,8 @@ export const validateAnmodningInfo = (
   const hasErrors: Array<boolean> = []
   const sed = replySed as H120Sed
 
-  const isArbeidsufoer = !!(sed.arbeidsufoer?.periodeStartdato || sed.arbeidsufoer?.periodeSluttdato)
-  const isArbeidsdyktig = !!sed.arbeidsdyktig?.dekkesKostnader
+  const isArbeidsufoer = sed.arbeidsufoer !== undefined
+  const isArbeidsdyktig = sed.arbeidsdyktig !== undefined
   const hasSelection = isArbeidsufoer || isArbeidsdyktig
 
   if (!hasSelection) {

--- a/src/applications/SvarSed/BeroertYtelse/BeroertYtelse.tsx
+++ b/src/applications/SvarSed/BeroertYtelse/BeroertYtelse.tsx
@@ -65,11 +65,11 @@ const BeroertYtelse: React.FC<MainFormProps> = ({
   const setBeroertYtelse = (value: string) => {
     const trimmed = value.trim()
     dispatch(updateReplySed('beroertYtelse', trimmed))
-    if (trimmed !== 'familieytelse' && sed.familie) {
-      dispatch(updateReplySed('familie', undefined))
+    if (trimmed !== 'familieytelse' && sed.familieYtelse) {
+      dispatch(updateReplySed('familieYtelse', undefined))
     }
-    if (!isAWODYtelse(trimmed) && sed.arbeidsulykkeyrkessykdom) {
-      dispatch(updateReplySed('arbeidsulykkeyrkessykdom', undefined))
+    if (!isAWODYtelse(trimmed) && sed.yrkesskade) {
+      dispatch(updateReplySed('yrkesskade', undefined))
     }
     if (validation[namespace + '-beroertYtelse']) {
       dispatch(resetValidation(namespace + '-beroertYtelse'))

--- a/src/applications/SvarSed/FamilieytelseSpoersmaal/FamilieytelseSpoersmaal.tsx
+++ b/src/applications/SvarSed/FamilieytelseSpoersmaal/FamilieytelseSpoersmaal.tsx
@@ -56,14 +56,14 @@ const FamilieytelseSpoersmaal: React.FC<MainFormProps> = ({
   })
 
   const setEtterspurtDokumentasjon = (values: string[]) => {
-    dispatch(updateReplySed('familie.etterspurtDokumentasjon', values.length > 0 ? values : undefined))
+    dispatch(updateReplySed('familieYtelse.etterspurtDokumentasjon', values.length > 0 ? values : undefined))
     if (validation[namespace + '-etterspurtDokumentasjon']) {
       dispatch(resetValidation(namespace + '-etterspurtDokumentasjon'))
     }
   }
 
   const setAnnenDokumentasjon = (value: string) => {
-    dispatch(updateReplySed('familie.annenDokumentasjon', value.trim() || undefined))
+    dispatch(updateReplySed('familieYtelse.annenDokumentasjon', value.trim() || undefined))
   }
 
   return (
@@ -76,7 +76,7 @@ const FamilieytelseSpoersmaal: React.FC<MainFormProps> = ({
         <CheckboxGroup
           legend={t('label:etterspurt-dokumentasjon-familieytelser')}
           error={validation[namespace + '-etterspurtDokumentasjon']?.feilmelding}
-          value={sed.familie?.etterspurtDokumentasjon ?? []}
+          value={sed.familieYtelse?.etterspurtDokumentasjon ?? []}
           onChange={setEtterspurtDokumentasjon}
         >
           {familieEtterspurtDokumentasjonOptions.map(opt => (
@@ -93,7 +93,7 @@ const FamilieytelseSpoersmaal: React.FC<MainFormProps> = ({
           label={t('label:annen-dokumentasjon-familieytelser')}
           maxLength={500}
           onChanged={setAnnenDokumentasjon}
-          value={sed.familie?.annenDokumentasjon}
+          value={sed.familieYtelse?.annenDokumentasjon}
         />
       </VStack>
     </Box>

--- a/src/applications/SvarSed/FamilieytelseSpoersmaal/validation.ts
+++ b/src/applications/SvarSed/FamilieytelseSpoersmaal/validation.ts
@@ -19,9 +19,9 @@ export const validateFamilieytelseSpoersmaal = (
   const hasErrors: Array<boolean> = []
   const sed = replySed as H120Sed
 
-  if (sed.familie?.annenDokumentasjon?.trim()) {
+  if (sed.familieYtelse?.annenDokumentasjon?.trim()) {
     hasErrors.push(checkIfNotEmpty(v, {
-      needle: sed.familie?.etterspurtDokumentasjon,
+      needle: sed.familieYtelse?.etterspurtDokumentasjon,
       id: namespace + '-etterspurtDokumentasjon',
       message: 'validation:noEtterspurtDokumentasjonFamilieytelser',
       personName
@@ -29,7 +29,7 @@ export const validateFamilieytelseSpoersmaal = (
   }
 
   hasErrors.push(checkLength(v, {
-    needle: sed.familie?.annenDokumentasjon,
+    needle: sed.familieYtelse?.annenDokumentasjon,
     max: 500,
     id: namespace + '-annenDokumentasjon',
     message: 'validation:textOverX',

--- a/src/applications/SvarSed/PersonOpplysninger/PersonOpplysninger.tsx
+++ b/src/applications/SvarSed/PersonOpplysninger/PersonOpplysninger.tsx
@@ -330,7 +330,7 @@ const PersonOpplysninger: React.FC<MainFormProps> = ({
             </HGrid>
           )}
           {showFoedested &&
-            <VStack>
+            <>
               <Heading size='small'>
                 {t('label:fødested')}
               </Heading>
@@ -341,7 +341,7 @@ const PersonOpplysninger: React.FC<MainFormProps> = ({
                 personName={personName}
                 validation={validation}
               />
-            </VStack>
+            </>
           }
         </VStack>
       </Box>

--- a/src/declarations/h120.d.ts
+++ b/src/declarations/h120.d.ts
@@ -118,7 +118,7 @@ export interface FamilieYtelse {
 
 // ===== H120 Bruker =====
 
-export interface H120Bruker {
+export interface Bruker {
   personInfo: PersonInfo
   adresse?: Adresse
 }
@@ -126,7 +126,7 @@ export interface H120Bruker {
 // ===== H120 SED =====
 
 export interface H120Sed extends BaseReplySed {
-  bruker: H120Bruker
+  bruker: Bruker
   ytterligereInfo?: string
   beroertYtelse?: BeroertYtelseType
   kravetsArt?: KravetsArt

--- a/src/declarations/h120.d.ts
+++ b/src/declarations/h120.d.ts
@@ -1,4 +1,4 @@
-import { Adresse, BaseReplySed, PersonInfo } from 'declarations/sed'
+import {Adresse, BaseReplySed, Epost, PersonInfo, Telefon} from 'declarations/sed'
 
 // ===== Berørt ytelse (Section 2) =====
 
@@ -121,6 +121,8 @@ export interface FamilieYtelse {
 export interface Bruker {
   personInfo: PersonInfo
   adresse?: Adresse
+  epost?: Array<Epost>
+  telefon?: Array<Telefon>
 }
 
 // ===== H120 SED =====

--- a/src/declarations/h120.d.ts
+++ b/src/declarations/h120.d.ts
@@ -1,4 +1,4 @@
-import { HSed } from 'declarations/sed'
+import { Adresse, BaseReplySed, PersonInfo } from 'declarations/sed'
 
 // ===== Berørt ytelse (Section 2) =====
 
@@ -38,7 +38,7 @@ export interface KravetsArt {
   spesielleKravTilDokumentasjon?: string
 }
 
-// ===== AWOD — Arbeidsulykke/yrkessykdom (Section 4) =====
+// ===== Yrkesskade — Arbeidsulykke/yrkessykdom (Section 6) =====
 
 export type AWODType = 'arbeidsulykke' | 'yrkessykdom'
 
@@ -71,7 +71,7 @@ export interface Arbeidsgiver {
   identifikator?: Array<ArbeidsgiverIdentifikator>
 }
 
-export interface Arbeidsulykkeyrkessykdom {
+export interface Yrkesskade {
   type?: AWODType
   dato?: string
   brukerStatus?: BrukerStatusType
@@ -82,18 +82,21 @@ export interface Arbeidsulykkeyrkessykdom {
   arbeidsgiver?: Arbeidsgiver
 }
 
-// ===== Informasjon om anmodningen (Section 5) =====
+// ===== Arbeidsufoer / Arbeidsdyktig (Section 4) =====
 
-export type DekningKostnaderType = 'ja' | 'nei' | 'gjelder_ikke'
+export type DekkesKostnaderType = 'ja' | 'nei' | 'gjelder_ikke'
 
-export interface AnmodningInfo {
-  gjelderArbeidsufoerhet?: boolean
+export interface Arbeidsufoer {
   periodeStartdato?: string
   periodeSluttdato?: string
-  dekningKostnader?: DekningKostnaderType
+  dekkesKostnader?: DekkesKostnaderType
 }
 
-// ===== Familie (Section 6) =====
+export interface Arbeidsdyktig {
+  dekkesKostnader?: DekkesKostnaderType
+}
+
+// ===== FamilieYtelse (Section 5) =====
 
 export type FamilieEtterspurtDokumentasjonType =
   | 'grad_av_selvhjulpenhet'
@@ -108,17 +111,27 @@ export type FamilieEtterspurtDokumentasjonType =
   | 'prognose'
   | 'grad_av_inntektsevne'
 
-export interface Familie {
+export interface FamilieYtelse {
   etterspurtDokumentasjon?: Array<FamilieEtterspurtDokumentasjonType>
   annenDokumentasjon?: string
 }
 
+// ===== H120 Bruker =====
+
+export interface H120Bruker {
+  personInfo: PersonInfo
+  adresse?: Adresse
+}
+
 // ===== H120 SED =====
 
-export interface H120Sed extends HSed {
+export interface H120Sed extends BaseReplySed {
+  bruker: H120Bruker
+  ytterligereInfo?: string
   beroertYtelse?: BeroertYtelseType
   kravetsArt?: KravetsArt
-  arbeidsulykkeyrkessykdom?: Arbeidsulykkeyrkessykdom
-  anmodningInfo?: AnmodningInfo
-  familie?: Familie
+  yrkesskade?: Yrkesskade
+  arbeidsufoer?: Arbeidsufoer
+  arbeidsdyktig?: Arbeidsdyktig
+  familieYtelse?: FamilieYtelse
 }

--- a/src/mocks/seds/h120.json
+++ b/src/mocks/seds/h120.json
@@ -24,16 +24,12 @@
         }
       ]
     },
-    "adresser": [
-      {
-        "type": "bosted",
-        "gate": "Storgata 1",
-        "postnummer": "0101",
-        "by": "Oslo",
-        "land": "NO",
-        "landkode": "NOR"
-      }
-    ]
+    "adresse": {
+      "gate": "Storgata 1",
+      "postnummer": "0101",
+      "by": "Oslo",
+      "landkode": "NOR"
+    }
   },
   "beroertYtelse": "sykepenger_som_kontantytelse_i_forbindelse_med_arbeidsuførhet",
   "kravetsArt": {
@@ -42,15 +38,12 @@
     ],
     "etterspurtDokumentasjon": [
       "standard_medisinsk_rapport"
-    ],
-    "annenDokumentasjon": "",
-    "spesielleKravTilDokumentasjon": ""
+    ]
   },
-  "anmodningInfo": {
-    "gjelderArbeidsufoerhet": true,
+  "arbeidsufoer": {
     "periodeStartdato": "2025-01-01",
     "periodeSluttdato": "2025-06-30",
-    "dekningKostnader": "ja"
+    "dekkesKostnader": "ja"
   },
-  "ytterligereInformasjon": ""
+  "ytterligereInfo": ""
 }

--- a/src/mocks/seds/h120.json
+++ b/src/mocks/seds/h120.json
@@ -29,7 +29,25 @@
       "postnummer": "0101",
       "by": "Oslo",
       "landkode": "NOR"
-    }
+    },
+    "epost": [
+      {
+        "adresse": "homer@simpsons.com"
+      },
+      {
+        "adresse": "homer.simpson@springfield-npp.com"
+      }
+    ],
+    "telefon": [
+      {
+        "type": "hjem",
+        "nummer": "+4790000001"
+      },
+      {
+        "type": "mobil",
+        "nummer": "+4790000002"
+      }
+    ]
   },
   "beroertYtelse": "sykepenger_som_kontantytelse_i_forbindelse_med_arbeidsuførhet",
   "kravetsArt": {

--- a/src/pages/SvarSed/SEDEdit.tsx
+++ b/src/pages/SvarSed/SEDEdit.tsx
@@ -11,7 +11,7 @@ import {
 } from 'actions/svarsed'
 import { resetValidation, setValidation } from 'actions/validation'
 import Adresser from 'applications/SvarSed/Adresser/Adresser'
-import AdresseH120 from 'applications/SvarSed/Adresser/Adresse'
+import Adresse from 'applications/SvarSed/Adresser/Adresse'
 import AnmodningOmAdresse from '../../applications/SvarSed/Adresser/AnmodningOmAdresse'
 import Anmodning from 'applications/SvarSed/Anmodning/Anmodning'
 import AnmodningsPeriode from 'applications/SvarSed/AnmodningsPeriode/AnmodningsPeriode'
@@ -439,7 +439,7 @@ const SEDEdit = (): JSX.Element => {
                   { label: t('el:option-mainform-person'), value: 'personlight', component: PersonLight, type: 'X' },
                   { label: t('el:option-mainform-nasjonaliteter'), value: 'nasjonaliteter', component: Nasjonaliteter, type: ['F', 'U', 'H', 'S'], adult: true, barn: true, condition: () => !isH021Sed(replySed) },
                   { label: t('el:option-mainform-adresser'), value: 'adresser', component: Adresser, type: ['F', 'H'], adult: true, barn: true, condition: () => !isH120Sed(replySed) && !isH021Sed(replySed) },
-                  { label: t('el:option-mainform-adresse'), value: 'adresseH120', component: AdresseH120, type: ['H120'], adult: true },
+                  { label: t('el:option-mainform-adresse'), value: 'adresseH120', component: Adresse, type: ['H120'], adult: true },
                   { label: t('el:option-mainform-adresse'), value: 'adresse', component: Adresser, type: ['S'], options: {singleAdress: true}},
                   { label: t('el:option-mainform-adresseH001'), value: 'adresseAnmodning', component: AnmodningOmAdresse, type: ['H001'], adult: true, barn: true, condition: () => CDM_VERSJON >= 4.4 },
                   { label: t('el:option-mainform-kontakt'), value: 'kontaktinformasjon', component: Kontaktinformasjon, type: 'F', adult: true },

--- a/src/pages/SvarSed/SEDEdit.tsx
+++ b/src/pages/SvarSed/SEDEdit.tsx
@@ -442,7 +442,7 @@ const SEDEdit = (): JSX.Element => {
                   { label: t('el:option-mainform-adresse'), value: 'adresseH120', component: Adresse, type: ['H120'], adult: true },
                   { label: t('el:option-mainform-adresse'), value: 'adresse', component: Adresser, type: ['S'], options: {singleAdress: true}},
                   { label: t('el:option-mainform-adresseH001'), value: 'adresseAnmodning', component: AnmodningOmAdresse, type: ['H001'], adult: true, barn: true, condition: () => CDM_VERSJON >= 4.4 },
-                  { label: t('el:option-mainform-kontakt'), value: 'kontaktinformasjon', component: Kontaktinformasjon, type: 'F', adult: true },
+                  { label: t('el:option-mainform-kontakt'), value: 'kontaktinformasjon', component: Kontaktinformasjon, type: ['F', 'H120'], adult: true },
                   { label: t('el:option-mainform-ytterligereinformasjon'), value: 'ytterligereInfo', component: YtterligereInfo, type: 'F003', spouse: true },
                   { label: t('el:option-mainform-trygdeordninger'), value: 'trygdeordning', component: Trygdeordning, type: ['F026', 'F027'], adult: true },
                   { label: t('el:option-mainform-aktivitetogtrygdeperioder'), value: 'aktivitetogtrygdeperioder', component: AktivitetOgTrygdeperioder, type: ['F001', 'F002'], adult: true, condition: () => CDM_VERSJON <= 4.3 },

--- a/src/pages/SvarSed/SEDEdit.tsx
+++ b/src/pages/SvarSed/SEDEdit.tsx
@@ -11,6 +11,7 @@ import {
 } from 'actions/svarsed'
 import { resetValidation, setValidation } from 'actions/validation'
 import Adresser from 'applications/SvarSed/Adresser/Adresser'
+import AdresseH120 from 'applications/SvarSed/Adresser/Adresse'
 import AnmodningOmAdresse from '../../applications/SvarSed/Adresser/AnmodningOmAdresse'
 import Anmodning from 'applications/SvarSed/Anmodning/Anmodning'
 import AnmodningsPeriode from 'applications/SvarSed/AnmodningsPeriode/AnmodningsPeriode'
@@ -438,7 +439,7 @@ const SEDEdit = (): JSX.Element => {
                   { label: t('el:option-mainform-person'), value: 'personlight', component: PersonLight, type: 'X' },
                   { label: t('el:option-mainform-nasjonaliteter'), value: 'nasjonaliteter', component: Nasjonaliteter, type: ['F', 'U', 'H', 'S'], adult: true, barn: true, condition: () => !isH021Sed(replySed) },
                   { label: t('el:option-mainform-adresser'), value: 'adresser', component: Adresser, type: ['F', 'H'], adult: true, barn: true, condition: () => !isH120Sed(replySed) && !isH021Sed(replySed) },
-                  { label: t('el:option-mainform-adresse'), value: 'adresseH120', component: Adresser, type: ['H120'], options: {singleAdress: true, defaultType: 'bosted'}, adult: true },
+                  { label: t('el:option-mainform-adresse'), value: 'adresseH120', component: AdresseH120, type: ['H120'], adult: true },
                   { label: t('el:option-mainform-adresse'), value: 'adresse', component: Adresser, type: ['S'], options: {singleAdress: true}},
                   { label: t('el:option-mainform-adresseH001'), value: 'adresseAnmodning', component: AnmodningOmAdresse, type: ['H001'], adult: true, barn: true, condition: () => CDM_VERSJON >= 4.4 },
                   { label: t('el:option-mainform-kontakt'), value: 'kontaktinformasjon', component: Kontaktinformasjon, type: 'F', adult: true },

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -1,4 +1,4 @@
-import {validateAdresser, validateAnmodningOmAdresse, ValidationAdresserProps} from 'applications/SvarSed/Adresser/validation'
+import {validateAdresser, validateAdresseH120, validateAnmodningOmAdresse, ValidationAdresseH120Props, ValidationAdresserProps} from 'applications/SvarSed/Adresser/validation'
 import { validateAnmodning, ValidationAnmodningProps } from 'applications/SvarSed/Anmodning/validation'
 import {
   validateAnmodningsPerioder, validateKrav,
@@ -427,9 +427,16 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
     hasErrors.push(performValidation<ValidationNasjonaliteterProps>(v, `svarsed-${personID}-nasjonaliteter`, validateNasjonaliteter, {
       statsborgerskaper, personName
     }, true))
-    hasErrors.push(performValidation<ValidationAdresserProps>(v, `svarsed-${personID}-adresser`, validateAdresser, {
-      adresser: _.get(replySed, `${personID}.adresser`), checkAdresseType: true, personName
-    }, true))
+    if (!isH120Sed(replySed)) {
+      hasErrors.push(performValidation<ValidationAdresserProps>(v, `svarsed-${personID}-adresser`, validateAdresser, {
+        adresser: _.get(replySed, `${personID}.adresser`), checkAdresseType: true, personName
+      }, true))
+    }
+    if (isH120Sed(replySed)) {
+      hasErrors.push(performValidation<ValidationAdresseH120Props>(v, `svarsed-${personID}-adresse`, validateAdresseH120, {
+        adresse: _.get(replySed, `${personID}.adresse`), personName
+      }, true))
+    }
     if (isH002Sed(replySed)) {
       hasErrors.push(performValidation<ValidationSvarPåForespørselProps>(v, `svarsed-${personID}-svarpåforespørsel`, validateSvarPåForespørsel, {
         replySed,

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -1,4 +1,4 @@
-import {validateAdresser, validateAdresseH120, validateAnmodningOmAdresse, ValidationAdresseH120Props, ValidationAdresserProps} from 'applications/SvarSed/Adresser/validation'
+import {validateAdresse, validateAdresser, validateAnmodningOmAdresse, ValidationAdresseProps, ValidationAdresserProps} from 'applications/SvarSed/Adresser/validation'
 import { validateAnmodning, ValidationAnmodningProps } from 'applications/SvarSed/Anmodning/validation'
 import {
   validateAnmodningsPerioder, validateKrav,
@@ -433,8 +433,8 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
       }, true))
     }
     if (isH120Sed(replySed)) {
-      hasErrors.push(performValidation<ValidationAdresseH120Props>(v, `svarsed-${personID}-adresseH120`, validateAdresseH120, {
-        adresse: _.get(replySed, `${personID}.adresse`), personName
+      hasErrors.push(performValidation<ValidationAdresseProps>(v, `svarsed-${personID}-adresseH120`, validateAdresse, {
+        adresse: _.get(replySed, `${personID}.adresse`), checkAdresseType: false, optional: true, personName
       }, true))
     }
     if (isH002Sed(replySed)) {

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -433,7 +433,7 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
       }, true))
     }
     if (isH120Sed(replySed)) {
-      hasErrors.push(performValidation<ValidationAdresseH120Props>(v, `svarsed-${personID}-adresse`, validateAdresseH120, {
+      hasErrors.push(performValidation<ValidationAdresseH120Props>(v, `svarsed-${personID}-adresseH120`, validateAdresseH120, {
         adresse: _.get(replySed, `${personID}.adresse`), personName
       }, true))
     }


### PR DESCRIPTION
Resolves [TEN-1690](https://jira.adeo.no/browse/TEN-1690)

## Changes
- **arbeidsulykkeyrkessykdom → yrkesskade**: Renamed field and all references in AWODSpoersmaal component and validation
- **familie → familieYtelse**: Renamed field and all references in FamilieytelseSpoersmaal component and validation
- **anmodningInfo → arbeidsufoer + arbeidsdyktig**: Replaced single object with two separate top-level objects. New component logic derives radio state from data (per TEN-1612 plan) instead of using the removed `gjelderArbeidsufoerhet` boolean
- **bruker.adresser (array) → bruker.adresse (single)**: Created new `Adresse.tsx` component for H120 single address without type field
- **kravetsArt**: No change (kept as-is)
- Updated mock data to match new DTO structure
- Updated BeroertYtelse cleanup logic for new field names

## Verification
- TypeScript typecheck passes (`tsc --noEmit`)
- Full build succeeds (`npm run build`)