### PR TITLE
fix: upgrade http-proxy-middleware 2.0.9 → 3.0.7 (TEN-1712)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eux-schema": "0.4.0",
         "express": "5.2.1",
         "file-saver": "2.0.5",
-        "http-proxy-middleware": "2.0.9",
+        "http-proxy-middleware": "^3.0.7",
         "i18next": "25.10.10",
         "i18next-browser-languagedetector": "8.2.1",
         "i18next-http-backend": "3.0.6",
@@ -8186,27 +8186,20 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
         "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -8783,16 +8776,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "14.2.0",
+  "version": "14.3.0-TEN-1712-UPGRADE-HTTP-PROXY-MIDDLEWARE",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "14.2.0",
+      "version": "14.3.0-TEN-1712-UPGRADE-HTTP-PROXY-MIDDLEWARE",
       "dependencies": {
         "@navikt/aksel-icons": "8.13.0",
         "@navikt/ds-css": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eux-schema": "0.4.0",
     "express": "5.2.1",
     "file-saver": "2.0.5",
-    "http-proxy-middleware": "2.0.9",
+    "http-proxy-middleware": "^3.0.7",
     "i18next": "25.10.10",
     "i18next-browser-languagedetector": "8.2.1",
     "i18next-http-backend": "3.0.6",
@@ -203,5 +203,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@14.3.0-TEN-1712-UPGRADE-HTTP-PROXY-MIDDLEWARE"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.2.0",
+  "version": "14.3.0-TEN-1712-UPGRADE-HTTP-PROXY-MIDDLEWARE",
   "private": true,
   "type": "module",
   "scripts": {
@@ -203,6 +203,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@14.2.0"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/server.mjs
+++ b/server.mjs
@@ -123,24 +123,24 @@ const apiAuth = function (scope) {
   }
 }
 
-const apiProxy = function (target, pathRewrite) {
+const apiProxy = function (target, mountPath) {
   //logger.debug('On apiProxy, with target ' + target)
-  return createProxyMiddleware( {
-    target: target,
-    logLevel: 'silent',
+  return createProxyMiddleware({
+    // v3: req.url no longer includes the mount path, so append it to target
+    target: target + mountPath,
     changeOrigin: true,
     xfwd: true,
-//    pathRewrite: pathRewrite,
-    onProxyReq: function onProxyReq(proxyReq, req, res) {
-      //logger.debug('proxy frontend: adding header auth ' + res.locals.on_behalf_of_authorization)
-      proxyReq.setHeader(
-        "Authorization",
-        res.locals.on_behalf_of_authorization
-      )
-      proxyReq.removeHeader('io.nais.wonderwall.session')
-      proxyReq.removeHeader('JSESSIONID')
-      proxyReq.removeHeader('cookie')
-      req.cookies
+    on: {
+      proxyReq: function (proxyReq, req, res) {
+        //logger.debug('proxy frontend: adding header auth ' + res.locals.on_behalf_of_authorization)
+        proxyReq.setHeader(
+          "Authorization",
+          res.locals.on_behalf_of_authorization
+        )
+        proxyReq.removeHeader('io.nais.wonderwall.session')
+        proxyReq.removeHeader('JSESSIONID')
+        proxyReq.removeHeader('cookie')
+      }
     }
   })
 }
@@ -189,27 +189,27 @@ app.get(["/oauth2/login"], async (req, res) => {
 app.use('/api',
   timedOut,
   apiAuth(process.env.VITE_NEESSI_BACKEND_TOKEN_SCOPE),
-  apiProxy(process.env.VITE_NEESSI_BACKEND_URL,{ '^/frontend/' : '/' })
+  apiProxy(process.env.VITE_NEESSI_BACKEND_URL, '/api')
 )
 app.use('/v2',
   timedOut,
   apiAuth(process.env.VITE_NEESSI_BACKEND_TOKEN_SCOPE),
-  apiProxy(process.env.VITE_NEESSI_BACKEND_URL,{ '^/frontend/' : '/' })
+  apiProxy(process.env.VITE_NEESSI_BACKEND_URL, '/v2')
 )
 app.use('/v3',
   timedOut,
   apiAuth(process.env.VITE_NEESSI_BACKEND_TOKEN_SCOPE),
-  apiProxy(process.env.VITE_NEESSI_BACKEND_URL,{ '^/frontend/' : '/' })
+  apiProxy(process.env.VITE_NEESSI_BACKEND_URL, '/v3')
 )
 app.use('/v4',
   timedOut,
   apiAuth(process.env.VITE_NEESSI_BACKEND_TOKEN_SCOPE),
-  apiProxy(process.env.VITE_NEESSI_BACKEND_URL,{ '^/frontend/' : '/' })
+  apiProxy(process.env.VITE_NEESSI_BACKEND_URL, '/v4')
 )
 app.use('/v5',
   timedOut,
   apiAuth(process.env.VITE_NEESSI_BACKEND_TOKEN_SCOPE),
-  apiProxy(process.env.VITE_NEESSI_BACKEND_URL,{ '^/frontend/' : '/' })
+  apiProxy(process.env.VITE_NEESSI_BACKEND_URL, '/v5')
 )
 
 // app.use('/websocket', socketProxy)


### PR DESCRIPTION
Resolves [TEN-1712](https://nav.atlassian.net/browse/TEN-1712)

## Changes

- **Bump** `http-proxy-middleware` from `2.0.9` to `3.0.7`
- **Remove `logLevel: 'silent'`** — option removed in v3; v3 is silent by default
- **Migrate `onProxyReq` → `on.proxyReq`** — v3 refactored proxy events under an `on` object
- **Append mount path to target** — v3 no longer patches `req.url` with the Express mount path; each `apiProxy` call now receives the mount segment (`/api`, `/v2`–`/v5`) and appends it to the backend URL so backend URLs are preserved
- **Remove dead `req.cookies` reference** and unused `pathRewrite` param

## Verification

- Frontend build passes (`npm run build`) with no new errors
- Proxy logic reviewed: Authorization header injection, cookie/session stripping unchanged — only restructured under `on.proxyReq`