### PR TITLE
fix: validate date format on date fields before sending to RINA (TEN-1578)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "14.5.0-TEN-1578-DATE-FORMAT-VALIDATION",
+  "version": "14.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "14.5.0-TEN-1578-DATE-FORMAT-VALIDATION",
+      "version": "14.5.0",
       "dependencies": {
         "@navikt/aksel-icons": "8.13.0",
         "@navikt/ds-css": "8.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "neessi",
-  "version": "14.4.0",
+  "version": "14.5.0-TEN-1578-DATE-FORMAT-VALIDATION",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "neessi",
-      "version": "14.4.0",
+      "version": "14.5.0-TEN-1578-DATE-FORMAT-VALIDATION",
       "dependencies": {
         "@navikt/aksel-icons": "8.13.0",
         "@navikt/ds-css": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.5.0-TEN-1578-DATE-FORMAT-VALIDATION",
+  "version": "14.5.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -153,5 +153,5 @@
   ],
   "readme": "ERROR: No README data found!",
   "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@14.5.0-TEN-1578-DATE-FORMAT-VALIDATION"
+  "_id": "neessi@14.5.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neessi",
-  "version": "14.4.0",
+  "version": "14.5.0-TEN-1578-DATE-FORMAT-VALIDATION",
   "private": true,
   "type": "module",
   "scripts": {
@@ -152,6 +152,5 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys",
-  "_id": "neessi@14.4.0"
+  "disabled-homepage": "http://eesi2.no/melosys"
 }

--- a/package.json
+++ b/package.json
@@ -152,5 +152,6 @@
     "defaults"
   ],
   "readme": "ERROR: No README data found!",
-  "disabled-homepage": "http://eesi2.no/melosys"
+  "disabled-homepage": "http://eesi2.no/melosys",
+  "_id": "neessi@14.5.0-TEN-1578-DATE-FORMAT-VALIDATION"
 }

--- a/src/applications/SvarSed/Adresser/validation.ts
+++ b/src/applications/SvarSed/Adresser/validation.ts
@@ -1,7 +1,7 @@
 import { Adresse } from 'declarations/sed'
 import { Validation } from 'declarations/types'
 import { getIdx } from 'utils/namespace'
-import {checkIfNotEmpty, checkLength} from 'utils/validation'
+import {checkIfNotEmpty, checkLength, checkValidDateFormat} from 'utils/validation'
 
 export interface ValidationAdresseProps {
   adresse: Adresse | undefined
@@ -15,6 +15,7 @@ export interface ValidationAdresserProps {
   adresser: Array<Adresse> | undefined
   checkAdresseType: boolean
   personName?: string
+  botidilandetsiden?: string
 }
 
 export const validateAdresse = (
@@ -105,7 +106,8 @@ export const validateAdresser = (
   {
     adresser,
     checkAdresseType,
-    personName
+    personName,
+    botidilandetsiden
   }: ValidationAdresserProps
 ): boolean => {
   const hasErrors: Array<boolean> = []
@@ -117,6 +119,14 @@ export const validateAdresser = (
       personName
     }))
   })
+
+  hasErrors.push(checkValidDateFormat(validation, {
+    needle: botidilandetsiden,
+    id: namespace + '-botidilandetsiden',
+    message: 'validation:invalidDateFormat',
+    personName
+  }))
+
   return hasErrors.find(value => value) !== undefined
 }
 

--- a/src/applications/SvarSed/Adresser/validation.ts
+++ b/src/applications/SvarSed/Adresser/validation.ts
@@ -1,7 +1,8 @@
-import { Adresse } from 'declarations/sed'
+import { Adresse, ReplySed } from 'declarations/sed'
 import { Validation } from 'declarations/types'
 import { getIdx } from 'utils/namespace'
-import {checkIfNotEmpty, checkLength} from 'utils/validation'
+import { isS040Sed } from 'utils/sed'
+import {checkIfNotEmpty, checkLength, checkValidDateFormat} from 'utils/validation'
 
 export interface ValidationAdresseProps {
   adresse: Adresse | undefined
@@ -15,6 +16,8 @@ export interface ValidationAdresserProps {
   adresser: Array<Adresse> | undefined
   checkAdresseType: boolean
   personName?: string
+  replySed?: ReplySed
+  botidilandetsiden?: string
 }
 
 export const validateAdresse = (
@@ -105,7 +108,9 @@ export const validateAdresser = (
   {
     adresser,
     checkAdresseType,
-    personName
+    personName,
+    replySed,
+    botidilandetsiden
   }: ValidationAdresserProps
 ): boolean => {
   const hasErrors: Array<boolean> = []
@@ -117,6 +122,15 @@ export const validateAdresser = (
       personName
     }))
   })
+
+  if (isS040Sed(replySed)) {
+    hasErrors.push(checkValidDateFormat(validation, {
+      needle: botidilandetsiden,
+      id: namespace + '-botidilandetsiden',
+      message: 'validation:invalidDateFormat',
+      personName
+    }))
+  }
 
   return hasErrors.find(value => value) !== undefined
 }

--- a/src/applications/SvarSed/Adresser/validation.ts
+++ b/src/applications/SvarSed/Adresser/validation.ts
@@ -1,7 +1,7 @@
 import { Adresse } from 'declarations/sed'
 import { Validation } from 'declarations/types'
 import { getIdx } from 'utils/namespace'
-import {checkIfNotEmpty, checkLength, checkValidDateFormat} from 'utils/validation'
+import {checkIfNotEmpty, checkLength} from 'utils/validation'
 
 export interface ValidationAdresseProps {
   adresse: Adresse | undefined
@@ -15,7 +15,6 @@ export interface ValidationAdresserProps {
   adresser: Array<Adresse> | undefined
   checkAdresseType: boolean
   personName?: string
-  botidilandetsiden?: string
 }
 
 export const validateAdresse = (
@@ -106,8 +105,7 @@ export const validateAdresser = (
   {
     adresser,
     checkAdresseType,
-    personName,
-    botidilandetsiden
+    personName
   }: ValidationAdresserProps
 ): boolean => {
   const hasErrors: Array<boolean> = []
@@ -119,13 +117,6 @@ export const validateAdresser = (
       personName
     }))
   })
-
-  hasErrors.push(checkValidDateFormat(validation, {
-    needle: botidilandetsiden,
-    id: namespace + '-botidilandetsiden',
-    message: 'validation:invalidDateFormat',
-    personName
-  }))
 
   return hasErrors.find(value => value) !== undefined
 }

--- a/src/applications/SvarSed/Motregninger/validation.ts
+++ b/src/applications/SvarSed/Motregninger/validation.ts
@@ -1,4 +1,4 @@
-import { addError, checkIfNotEmpty, checkLength } from 'utils/validation'
+import { addError, checkIfNotEmpty, checkLength, checkValidDateFormat } from 'utils/validation'
 import { validatePeriode } from 'components/Forms/validation'
 import {F002Sed, Motregning, Motregninger, ReplySed} from 'declarations/sed'
 import { Validation } from 'declarations/types'
@@ -106,6 +106,13 @@ export const validateMotregning = (
     periodeType: 'simple',
     mandatoryStartdato: true,
     mandatorySluttdato: true,
+    personName: formalName
+  }))
+
+  hasErrors.push(checkValidDateFormat(v, {
+    needle: motregning?.vedtaksdato,
+    id: namespace + (nsIndex ?? type) + '-vedtaksdato',
+    message: 'validation:invalidDateFormat',
     personName: formalName
   }))
 

--- a/src/applications/SvarSed/SisteAnsettelseInfo/validation.ts
+++ b/src/applications/SvarSed/SisteAnsettelseInfo/validation.ts
@@ -2,7 +2,7 @@ import { SisteAnsettelseInfo, Utbetaling } from 'declarations/sed'
 import { Validation } from 'declarations/types'
 import _ from 'lodash'
 import { getIdx } from 'utils/namespace'
-import {addError, checkIfInteger, checkIfNotEmpty, checkIfNotNumber, checkLength} from 'utils/validation'
+import {addError, checkIfInteger, checkIfNotEmpty, checkIfNotNumber, checkLength, checkValidDateFormat} from 'utils/validation'
 
 
 export interface ValidationUtbetalingProps {
@@ -46,6 +46,13 @@ export const validateUtbetaling = (
       hasErrors.push(addError(v, {
         id: namespace + idx + '-loennTilDato',
         message: 'validation:noLoennTilDato',
+        personName
+      }))
+    } else if (etterbetalinger?.utbetalingType?.trim() === 'inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet') {
+      hasErrors.push(checkValidDateFormat(v, {
+        needle: etterbetalinger?.loennTilDato,
+        id: namespace + idx + '-loennTilDato',
+        message: 'validation:invalidDateFormat',
         personName
       }))
     }

--- a/src/applications/SvarSed/SisteAnsettelseInfo/validation.ts
+++ b/src/applications/SvarSed/SisteAnsettelseInfo/validation.ts
@@ -41,20 +41,21 @@ export const validateUtbetaling = (
   }))
 
   if (!_.isEmpty(etterbetalinger?.utbetalingType?.trim())) {
-    if (etterbetalinger?.utbetalingType?.trim() === 'inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet' &&
-      _.isEmpty(etterbetalinger?.loennTilDato?.trim())) {
-      hasErrors.push(addError(v, {
-        id: namespace + idx + '-loennTilDato',
-        message: 'validation:noLoennTilDato',
-        personName
-      }))
-    } else if (etterbetalinger?.utbetalingType?.trim() === 'inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet') {
-      hasErrors.push(checkValidDateFormat(v, {
-        needle: etterbetalinger?.loennTilDato,
-        id: namespace + idx + '-loennTilDato',
-        message: 'validation:invalidDateFormat',
-        personName
-      }))
+    if (etterbetalinger?.utbetalingType?.trim() === 'inntekter_for_periode_etter_avslutning_av_arbeidsforhold_eller_opphør_i_selvstendig_næringsvirksomhet') {
+      if(_.isEmpty(etterbetalinger?.loennTilDato?.trim())) {
+        hasErrors.push(addError(v, {
+          id: namespace + idx + '-loennTilDato',
+          message: 'validation:noLoennTilDato',
+          personName
+        }))
+      } else {
+        hasErrors.push(checkValidDateFormat(v, {
+          needle: etterbetalinger?.loennTilDato,
+          id: namespace + idx + '-loennTilDato',
+          message: 'validation:invalidDateFormat',
+          personName
+        }))
+      }
     }
   }
 

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/DatoEndredeForhold.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/DatoEndredeForhold.tsx
@@ -57,7 +57,7 @@ const DatoEndredeForhold: React.FC<MainFormProps> = ({
           <DateField
             error={validation[namespace + '-dato-for-endrede-forhold']?.feilmelding}
             namespace={namespace}
-            id={namespace + '-dato-for-endrede-forhold'}
+            id={'dato-for-endrede-forhold'}
             label={t('label:dato-for-endrede-forhold')}
             hideLabel={true}
             onChanged={(v) => setAnnenInformasjonBarnetProperty('datoEndredeForhold', v)}

--- a/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/validation.tsx
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmAnnenInformasjonOmBarnet/validation.tsx
@@ -3,7 +3,7 @@ import {
   AnnenInformasjonBarnet_V42,
   AnnenInformasjonBarnet_V43
 } from "../../../declarations/sed";
-import {checkIfFilledOut, checkIfNotEmpty, checkLength, doNothing} from "../../../utils/validation";
+import {checkIfFilledOut, checkIfNotEmpty, checkLength, checkValidDateFormat} from "../../../utils/validation";
 import performValidation from "../../../utils/performValidation";
 
 export interface ValidationAnnenInformasjonBarnetProps {
@@ -226,10 +226,10 @@ export const validateDatoForEndredeForhold = (
 
   const hasErrors: Array<boolean> = []
 
-  hasErrors.push(doNothing(v, {
-    needle: annenInformasjonBarnet,
+  hasErrors.push(checkValidDateFormat(v, {
+    needle: (annenInformasjonBarnet as AnnenInformasjonBarnet_V42)?.datoEndredeForhold,
     id: namespace + '-dato-for-endrede-forhold',
-    message: 'dummy'
+    message: 'validation:invalidDateFormat'
   }))
 
   return hasErrors.find(value => value) !== undefined

--- a/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonAnnenPersonOgAvdoede/validation.ts
+++ b/src/applications/SvarSed/SvarPaaAnmodningOmBarnepensjon/RelasjonAnnenPersonOgAvdoede/validation.ts
@@ -6,7 +6,7 @@ import {
 } from 'declarations/sed'
 import { Validation } from 'declarations/types'
 import { getIdx } from 'utils/namespace'
-import {checkIfDuplicate, checkIfNotEmpty, checkLength} from 'utils/validation'
+import {checkIfDuplicate, checkIfNotEmpty, checkLength, checkValidDateFormat} from 'utils/validation'
 import {ValidationYtelseTilForeldreloeseProps} from "../validation";
 
 export interface ValidationRelasjonProps {
@@ -40,6 +40,12 @@ export const validateRelasjon = (
   hasErrors.push(validatePeriode(v, namespace + idx + '-periode', {
     periode: relasjon?.periode,
     mandatoryStartdato: false,
+  }))
+
+  hasErrors.push(checkValidDateFormat(v, {
+    needle: relasjon?.relasjonsstartdato,
+    id: namespace + idx + '-relasjonsstartdato',
+    message: 'validation:invalidDateFormat'
   }))
 
   hasErrors.push(checkIfDuplicate(v, {

--- a/src/components/DateField/DateField.tsx
+++ b/src/components/DateField/DateField.tsx
@@ -1,8 +1,13 @@
 import React, {useEffect, useState} from 'react'
 
 import { TextField } from '@navikt/ds-react'
-import {useAppDispatch} from "../../store";
+import _ from 'lodash'
+import {useAppDispatch, useAppSelector} from "../../store";
 import {setTextFieldDirty} from "../../actions/ui";
+import {resetValidation, setValidation} from "../../actions/validation";
+import {addError} from "../../utils/validation";
+import { State } from "declarations/reducers";
+import { Validation } from "declarations/types";
 import moment, {Moment} from "moment/moment";
 import {useTranslation} from "react-i18next";
 
@@ -72,11 +77,35 @@ const DateField = ({
 
 }: DateFieldProps) => {
   const dispatch = useAppDispatch()
+  const validation: Validation = useAppSelector((state: State) => state.validation.status)
   const { t } = useTranslation()
   const [_dato, _setDato] = useState<string>(() => isDateValidFormat(dateValue) ? toDateFormat(dateValue, uiFormat!) : dateValue ? dateValue : '')
   const [_error, _setError] = useState<string | undefined>(() => undefined)
   const [_blurred, _setBlurred] = useState<boolean>(() => false)
 
+  const skjemaelementId = namespace + '-' + id
+
+  const onDateBlur = () => {
+    if(isDateValidFormat(_dato)){
+      _setError(undefined)
+      const date = toDateFormat(_dato, finalFormat!)
+      onChanged(date)
+      dispatch(setTextFieldDirty(false))
+      if (validation[skjemaelementId]) {
+        dispatch(resetValidation(skjemaelementId))
+      }
+    } else {
+      _setError(t('validation:invalidDateFormat'))
+      onChanged(_dato)
+      const clonedValidation: Validation = _.cloneDeep(validation)
+      addError(clonedValidation, {
+        id: skjemaelementId,
+        message: 'validation:invalidDateFormat'
+      })
+      dispatch(setValidation(clonedValidation))
+    }
+    _setBlurred(!_blurred)
+  }
 
   useEffect(() => {
     if(isDateValidFormat(dateValue)){
@@ -94,19 +123,6 @@ const DateField = ({
       _setError(undefined)
     }
   }, [resetError])
-
-  const onDateBlur = () => {
-    if(isDateValidFormat(_dato)){
-      _setError(undefined)
-      const date = toDateFormat(_dato, finalFormat!)
-      onChanged(date)
-      dispatch(setTextFieldDirty(false))
-    } else {
-      _setError(t('validation:invalidDateFormat'))
-      onChanged(_dato)
-    }
-    _setBlurred(!_blurred)
-  }
 
   const onDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     _setDato(e.target.value)

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -135,7 +135,7 @@ import {
   isX010Sed, isX011Sed, isX012Sed,
   isXSed
 } from 'utils/sed'
-import { checkLength } from 'utils/validation'
+import { checkLength, checkValidDateFormat } from 'utils/validation'
 import {getAllArbeidsPerioderHaveSluttDato, getNrOfArbeidsPerioder} from "../../utils/arbeidsperioder";
 import {validateYtterligereInfo, ValidationYtterligereInfoProps} from "../../applications/SvarSed/YtterligereInfo/validation";
 import { validateVedtak as validateVedtakF003, ValidationVedtakProps as ValidationVedtakF003Props } from 'applications/SvarSed/VedtakForF003/validation'
@@ -256,7 +256,7 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
 
       const adresser: Array<Adresse> | undefined = _.get(replySed, `${personID}.adresser`)
       hasErrors.push(performValidation<ValidationAdresserProps>(v, `svarsed-${personID}-adresser`, validateAdresser, {
-        adresser, checkAdresseType: false, personName, botidilandetsiden: _.get(replySed, `${personID}.botidilandetsiden`)
+        adresser, checkAdresseType: false, personName
       }, true))
     }
 
@@ -429,7 +429,7 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
     }, true))
     if (!isH120Sed(replySed)) {
       hasErrors.push(performValidation<ValidationAdresserProps>(v, `svarsed-${personID}-adresser`, validateAdresser, {
-        adresser: _.get(replySed, `${personID}.adresser`), checkAdresseType: true, personName, botidilandetsiden: _.get(replySed, `${personID}.botidilandetsiden`)
+        adresser: _.get(replySed, `${personID}.adresser`), checkAdresseType: true, personName
       }, true))
     }
     if (isH120Sed(replySed)) {
@@ -677,6 +677,11 @@ export const validateSEDEdit = (
     hasErrors.push(performValidation<ValidationForespoerselProps>(v, 'forespoersel-sykdom', validateForespoersel, {
       sykdom: (replySed as S040Sed).sykdom
     }, true))
+    hasErrors.push(checkValidDateFormat(v, {
+      needle: _.get(replySed, `bruker.botidilandetsiden`),
+      id: `svarsed-bruker-adresser-botidilandetsiden`,
+      message: 'validation:invalidDateFormat'
+    }))
   }
 
   if(isS046Sed(replySed)){

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -256,7 +256,7 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
 
       const adresser: Array<Adresse> | undefined = _.get(replySed, `${personID}.adresser`)
       hasErrors.push(performValidation<ValidationAdresserProps>(v, `svarsed-${personID}-adresser`, validateAdresser, {
-        adresser, checkAdresseType: false, personName
+        adresser, checkAdresseType: false, personName, botidilandetsiden: _.get(replySed, `${personID}.botidilandetsiden`)
       }, true))
     }
 
@@ -429,7 +429,7 @@ export const validateMainForm = (v: Validation, _replySed: ReplySed, personID: s
     }, true))
     if (!isH120Sed(replySed)) {
       hasErrors.push(performValidation<ValidationAdresserProps>(v, `svarsed-${personID}-adresser`, validateAdresser, {
-        adresser: _.get(replySed, `${personID}.adresser`), checkAdresseType: true, personName
+        adresser: _.get(replySed, `${personID}.adresser`), checkAdresseType: true, personName, botidilandetsiden: _.get(replySed, `${personID}.botidilandetsiden`)
       }, true))
     }
     if (isH120Sed(replySed)) {

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -678,7 +678,7 @@ export const validateSEDEdit = (
       sykdom: (replySed as S040Sed).sykdom
     }, true))
     hasErrors.push(performValidation<ValidationAdresserProps>(v, 'svarsed-bruker-adresser', validateAdresser, {
-      adresser: undefined,
+      adresser: _.get(replySed, 'bruker.adresser'),
       checkAdresseType: false,
       replySed,
       botidilandetsiden: _.get(replySed, 'bruker.botidilandetsiden')

--- a/src/pages/SvarSed/mainValidation.ts
+++ b/src/pages/SvarSed/mainValidation.ts
@@ -135,7 +135,7 @@ import {
   isX010Sed, isX011Sed, isX012Sed,
   isXSed
 } from 'utils/sed'
-import { checkLength, checkValidDateFormat } from 'utils/validation'
+import { checkLength } from 'utils/validation'
 import {getAllArbeidsPerioderHaveSluttDato, getNrOfArbeidsPerioder} from "../../utils/arbeidsperioder";
 import {validateYtterligereInfo, ValidationYtterligereInfoProps} from "../../applications/SvarSed/YtterligereInfo/validation";
 import { validateVedtak as validateVedtakF003, ValidationVedtakProps as ValidationVedtakF003Props } from 'applications/SvarSed/VedtakForF003/validation'
@@ -677,11 +677,12 @@ export const validateSEDEdit = (
     hasErrors.push(performValidation<ValidationForespoerselProps>(v, 'forespoersel-sykdom', validateForespoersel, {
       sykdom: (replySed as S040Sed).sykdom
     }, true))
-    hasErrors.push(checkValidDateFormat(v, {
-      needle: _.get(replySed, `bruker.botidilandetsiden`),
-      id: `svarsed-bruker-adresser-botidilandetsiden`,
-      message: 'validation:invalidDateFormat'
-    }))
+    hasErrors.push(performValidation<ValidationAdresserProps>(v, 'svarsed-bruker-adresser', validateAdresser, {
+      adresser: undefined,
+      checkAdresseType: false,
+      replySed,
+      botidilandetsiden: _.get(replySed, 'bruker.botidilandetsiden')
+    }, true))
   }
 
   if(isS046Sed(replySed)){


### PR DESCRIPTION
Resolves [TEN-1578](https://jira.adeo.no/browse/TEN-1578)

## Problem
Invalid dates entered in `DateField` could be silently written to `replySed` and sent to RINA. The component only showed a local error that did not block save/send, and several form sections lacked any date-format validation.

## Changes
- **DateField** now writes a live validation error to redux on blur (keyed to the field's DOM id), so invalid dates appear immediately in the error summary and link to the field; cleared on valid blur.
- Added `checkValidDateFormat` to the section validations that were missing it (re-derived in `validateSEDEdit`, so save/send is now gated):
  - Adresser `botidilandetsiden` (reported S040 case)
  - SisteAnsettelseInfo `loennTilDato`
  - Motregninger `vedtaksdato`
  - RelasjonAnnenPersonOgAvdoede `relasjonsstartdato`
  - SvarPaaAnmodningOmAnnenInformasjonOmBarnet `datoEndredeForhold` (replaced no-op)

## Verification
- `npm run typecheck` ✅
- `npm run build` ✅