### PR TITLE
chore(deps): refresh lockfile to patch js-yaml and brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,9 +1067,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4294,9 +4294,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9244,9 +9244,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes Dependabot alerts **#281, #282, #283, #284**.

## What & why

Three transitive **devDependencies** are flagged for algorithmic-complexity DoS. In every case the parent package already declares a semver range that permits the patched version — the lockfile had simply drifted behind. So this needs **no `package.json` change and no `overrides` block**, just `npm update js-yaml brace-expansion`.

| Package | Current | Patched | Parent's declared range | Reached via |
|---|---|---|---|---|
| `js-yaml` | 4.2.0 | **4.3.1** | `^4.1.0` (cosmiconfig) | `vite-plugin-svgr` → `@svgr/core` |
| `js-yaml` | 3.14.2 | **3.15.1** | `^3.13.1` (`@istanbuljs/load-nyc-config`) | `jest` → `@jest/transform` → `babel-plugin-istanbul` |
| `brace-expansion` | 1.1.15 | **1.1.18** | `^1.1.7` (minimatch) | `jest` / `npm-run-all` → `glob` → `minimatch` |

Advisories:
- GHSA-52cp-r559-cp3m / CVE-2026-59869 — js-yaml: YAML merge-key chains force quadratic CPU consumption (High, 7.5)
- GHSA-h67p-54hq-rp68 / CVE-2026-53550 — js-yaml: quadratic-complexity DoS via repeated aliases in merge keys (Medium, 5.3)
- GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 — brace-expansion: DoS via exponential expansion of consecutive `{}` groups (Medium, 5.3)

## Severity in context

All three are **dev-only**, confirmed by tracing every path in `package-lock.json` (`"dev": true` on all instances). Nothing reaches the browser bundle or the Docker runtime, and the only YAML/globs parsed are our own `jest.config.cjs` and svgr config at build time — no attacker-controlled input. **Hygiene, not an incident.** Fixing anyway because it's free.

## Diff

`package.json` untouched. `package-lock.json`: **9 insertions, 9 deletions** — exactly the three version/resolved/integrity triples above. No other package in the tree moves.

## Verification

- ✅ `npm run typecheck` — clean
- ✅ `npm run build` — succeeds
- ✅ `npm test` — 28 failed / 17 passed suites, 84 failed / 107 passed tests: **identical to the `master` baseline** (pre-existing failures from old enzyme-style `wrapper.find()` calls, unrelated to this change)

Blast radius is limited to `jest`, `ts-jest`, `npm-run-all` and `vite-plugin-svgr`, so build + test covers it fully.

## Not included: alert #287 (react-router)

Being dismissed separately as *"vulnerable code is not actually used"*. GHSA-qwww-vcr4-c8h2 states it **only affects apps using the unstable RSC APIs**; this SPA uses only the declarative API (`BrowserRouter`, `Routes`, `Route`, `Link`, `NavLink`, `useNavigate`, `useParams`) with no RSC, no data router and no server-side action handling. There is also no safe fix: no 7.x backport exists, the only patched version is `react-router@8.3.0`, and v8 deletes the `react-router-dom` package entirely and is ESM-only — incompatible with our CJS Jest setup. Worth doing as a planned migration alongside a Jest/ESM modernisation, but not as a security fix.

## Follow-up worth considering

`.github/dependabot.yaml` ignores `version-update:semver-major` for `"*"`. Those `ignore` rules apply to security updates too, which is why #287 never produced a PR. Also, all four alerts here existed purely because the lockfile drifted behind ranges that already allowed the fix — a periodic lockfile-only `npm update` would prevent this class of alert entirely.